### PR TITLE
Fix603 get_param_set

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -514,12 +514,15 @@ get_param_set <- function(sims) {
     stop("`sims` must be of class netsim")
   }
 
-  random.names <- c("random.params", "random.params.values")
+  p.random <- sims[["param"]][["random.params.values"]]
+  fixed.names <- setdiff(
+    names(sims[["param"]]),
+    c(names(p.random), "random.params", "random.params.values")
+  )
 
-  p.random <- sims$param[[random.names[2]]]
-  p.fixed <- sims$param[!names(sims$param) %in% random.names]
+  p.fixed <- sims[["param"]][fixed.names]
 
-  d.param <- data.frame(sim = seq_len(sims$control$nsims))
+  d.param <- data.frame(sim = seq_len(sims[["control"]][["nsims"]]))
 
   # Fixed parameters
   for (i in seq_along(p.fixed)) {
@@ -527,8 +530,9 @@ get_param_set <- function(sims) {
     name <- names(p.fixed)[i]
     l <- length(val)
 
-    if (l > 1)
+    if (l > 1) {
       name <- paste0(name, "_", seq_len(l))
+    }
 
     names(val) <- name
     d.param <- cbind(d.param, t(val))
@@ -538,7 +542,6 @@ get_param_set <- function(sims) {
   for (i in seq_along(p.random)) {
     val <- p.random[[i]]
     name <- names(p.random)[i]
-    l <- length(val)
 
     if (is.list(val)) {
       l <- length(val[[1]])

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -140,14 +140,12 @@ test_that("get_sims error flags", {
     "dummy.param",
     "dummy.strat.param_1",
     "dummy.strat.param_2",
-    "groups",
-    "dummy.strat.param_1",
-    "dummy.strat.param_2"
+    "groups"
   )
 
   expect_is(d.set, "data.frame")
-  expect_equal(names(d.set), set.colnames)
+  expect_true(setequal(names(d.set), set.colnames))
   expect_error(get_param_set(control), "`sims` must be of class netsim")
-  expect_equal(dim(get_param_set(mod)), c(3, 13))
+  expect_equal(dim(get_param_set(mod)), c(3, length(set.colnames)))
 })
 

--- a/vignettes/model-parameters.Rmd
+++ b/vignettes/model-parameters.Rmd
@@ -5,7 +5,7 @@ vignette: >
   %\VignetteIndexEntry{model-parameters}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
-editor_options: 
+editor_options:
   chunk_output_type: console
 ---
 
@@ -29,7 +29,7 @@ In a model, *parameters* are the input variables used to define aspects of the s
 Therefore, in this vignette, we demonstrate how to implement:
 
 - Random parameters, which have a distribution of possible values rather than a single fixed value.
-- Time-varying parameters, which may change at specific time steps during the simulation. 
+- Time-varying parameters, which may change at specific time steps during the simulation.
 
 ## Random Parameters
 
@@ -112,7 +112,7 @@ After running 3 simulations we can see that 2 parameters are still displayed und
 We can inspect the values with the `get_param_set` function:
 
 ``` {r generators_inspect}
-str(mod$param$random.params.values)
+get_param_set(mod)
 ```
 
 #### Parameter set


### PR DESCRIPTION
fixes #603 

- `get_param_set` no longer prints the random parameters twice and now displays the correct values.
- the "model parameters" vignettes now uses `get_param_set`
- the tests of `get_param_set` are now correctly detecting when the data.frame is malformed