### PR TITLE
Simplify `print.control.net`

### DIFF
--- a/R/print.r
+++ b/R/print.r
@@ -484,17 +484,15 @@ print.control.net <- function(x, ...) {
     }
   }
 
-  funToPrint <- names(x)[grep(".FUN", names(x))]
-  funToPrint <- funToPrint[-which(funToPrint %in% c("initialize.FUN",
-                                                    "verbose.FUN"))]
-  if (is.null(x$module.order)) {
-    cat("Dynamic Modules:", funToPrint)
+  if (!is.null(x$module.order)) {
+    funToPrint <- x$module.order
   } else {
-    order <- unlist(lapply(funToPrint, function(y) which(y == x$module.order)))
-    funToPrint.mo <- funToPrint[order]
-    funtoPrint.nmo <- funToPrint[-which(funToPrint %in% x$module.order)]
-    cat("Dynamic Modules:", funToPrint)
+    funToPrint <- names(x)[grep(".FUN", names(x))]
+    funToPrint <- funToPrint[!funToPrint %in% c("initialize.FUN", "verbose.FUN")]
   }
+
+  cat("Dynamic Modules:", funToPrint)
+  cat("\n")
 
   invisible()
 }


### PR DESCRIPTION
fix #600 by removing the unused code and by printing "module.order" for
the module used when it is not `NULL`