### PR TITLE
Mention control_updater in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## EpiModel 2.2.1
+
+### NEW FEATURES
+
+-   Improved optional module `updater.net` allowing it to update the model controls as well as the parameters. See the vignette, "Working with model parameters."
+
 ## EpiModel 2.2.0
 
 ### NEW FEATURES

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 -   Addition of the `get_param_set` function that extracts from a `netsim` object the set of parameters used by each simulation. See the help page: `help("get_param_set")`.
 -   Developed a mechanism to store nodal attribute history over the course of a `netsim` simulation. See the vignette, "Working with attributes and summary statistics."
 -   Developed an optional module to define prevalence statistics (also called "epi stats") as functions to be passed to the model as control settings before each `netsim` simulation. This allows users to avoid updating the `prevalence.net` module. See the vignette, "Working with attributes and summary statistics."
--   Developed an optional module allowing the update of the model parameters over timesteps within `netsim` simulations (i.e., time-varying parameters). See the vignette, "Working with model parameters."
+-   Developed an optional module allowing the update of the model controls and parameters over timesteps within `netsim` simulations (i.e., time-varying parameters). See the vignette, "Working with model parameters."
 -   Improved the random parameterization programming interface to allow correlation between parameters in each simulation (e.g., the ability to pass in a multivariate parameter set for each simulation). See the vignette, "Working with model parameters."
 
 ### BUG FIXES

--- a/vignettes/model-parameters.Rmd
+++ b/vignettes/model-parameters.Rmd
@@ -300,3 +300,44 @@ list(
 This updater will set the value of `act.rate` to `0.5` as we saw earlier. But, for `inf.prob` we put a `function` (not a function call). In this case,
 `updater.net` will apply the `function` to the current value of `act.rate`. If we consider as in the previous example that `act.rate` is set to `0.1` by
 `param.net`, then its new value will be obtained by adding an Odds Ratio of 2 to the original value `plogis(qlogis(0.1) + log(2))`: `0.1818182`.
+
+## (Advanced) Time-Varying Control
+
+Similarly to time-varying parameters we can use time-varying controls. They work in the same way and use the same `updater` module. The two differences are:
+
+1. each **updater** will have a `control` sub-list instead of a `param` sub-list
+2. the list of **updaters** goes into `control$control.updater.list`
+
+```{r control-updater-example}
+# Create a `list.of.updaters`
+list.of.updaters <- list(
+  # this is one updater
+  list(
+    at = 100,
+    control = list(
+      resimulate.network = FALSE
+    )
+  ),
+  # this is another updater
+  list(
+    at = 125,
+    control = list(
+      verbose = FALSE
+    )
+  )
+)
+
+ # The `list.of.updaters` goes into `control.net` under `control.updater.list`
+ control <- control.net(
+   type = NULL, # must be NULL as we use a custom module
+   nsims = 1,
+   nsteps = 200,
+   verbose = TRUE,
+   resimulate.network = TRUE,
+   updater.FUN = updater.net,
+   infection.FUN = infection.net,
+   control.updater.list = list.of.updaters
+ )
+```
+
+This example set 2 **updaters**, one that will turn off network resimulation at timestep 100 and another toggling of the verbosity at step 125.

--- a/vignettes/model-parameters.Rmd
+++ b/vignettes/model-parameters.Rmd
@@ -308,7 +308,7 @@ Similarly to time-varying parameters we can use time-varying controls. They work
 1. each **updater** will have a `control` sub-list instead of a `param` sub-list
 2. the list of **updaters** goes into `control$control.updater.list`
 
-```{r control-updater-example}
+```{r control-updater-example, echo = FALSE}
 # Create a `list.of.updaters`
 list.of.updaters <- list(
   # this is one updater


### PR DESCRIPTION
Should I also modify the "Working with model parameters" vignette to add a section covering the control updaters?

Maybe "## (Advanced) Time-Varying Controls" with a succinct example as the mecanisms are the same as for Time-Varying Parameters
