### PR TITLE
Change defaults of cuml el, add explicit args

### DIFF
--- a/R/el_cuml.R
+++ b/R/el_cuml.R
@@ -71,17 +71,17 @@ get_cumulative_edgelist <- function(dat, network) {
 #'                 be removed from the cumulative edgelist (default = Inf)
 #'
 #' @section Truncation:
-#' To avoid storing a cumulative edgelist to long, the `truncate`
-#' parameter defines a number of steps after which an edge that is no longer
-#' active is truncated out of the cummulative edgelist. When `truncate == Inf`
-#' (default), no edge is ever removed. When `truncate == 0`, only the active
-#' edges are kept. You may want this behavior to keep track of the active edges
-#' start step.
+#' To avoid storing a cumulative edgelist too long, the `truncate` parameter
+#' defines a number of steps after which an edge that is no longer active is
+#' truncated out of the cumulative edgelist. When `truncate == Inf` (default),
+#' no edges are ever removed. When `truncate == 0`, only the active edges are
+#' kept. You may want this behavior to keep track of the active edges start
+#' step.
 #'
 #' @return an updated Master list object of network models
 #'
 #' @export
-update_cumulative_edgelist <- function(dat, network, truncate = Inf) {
+update_cumulative_edgelist <- function(dat, network, truncate = 0) {
   el <- get_edgelist(dat, network)
   el_cuml <- get_cumulative_edgelist(dat, network)
 
@@ -141,16 +141,16 @@ get_cumulative_edgelists_df <- function(dat, networks = NULL) {
   return(el_cuml_df)
 }
 
-#' @title Get the Previous Partners of a Set of Indexes
+#' @title Get the Previous Partners of a Set of Index Patients
 #'
-#' @param dat a Master list object of network models
-#' @param index_posit_ids the positional IDs of the indexes of interest
+#' @param dat a Master list object for \code{netsim}.
+#' @param index_posit_ids The positional IDs of the indexes of interest.
 #' @param networks the indexes of the networks to extract the partnerships from.
 #'                 If NULL (default) extract from all networks.
-#' @param max.age after how many steps a partnershipl that is no longer active
-#'                should be removed from the results (default = Inf)
-#' @param only.active should the inactive partners be removed from the results
-#'                    (default = FALSE)
+#' @param max.age after how many steps a partnership that is no longer active
+#'                should be removed from the results (default = Inf).
+#' @param only.active should inactive partners be removed from the results
+#'                    (default = FALSE).
 #'
 #' @return a \code{data.frame} with 5 columns:
 #'          index and partner, the unique_ids (see \code{get_unique_ids}) of the
@@ -161,6 +161,7 @@ get_cumulative_edgelists_df <- function(dat, networks = NULL) {
 #' @export
 get_partners <- function(dat, index_posit_ids, networks = NULL,
                          max.age = Inf, only.active = FALSE) {
+
   el_cuml_df <- get_cumulative_edgelists_df(dat, networks)
   index_unique_ids <- get_unique_ids(dat, index_posit_ids)
 

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -665,6 +665,12 @@ init.net <- function(i.num, r.num, i.num.g2, r.num.g2,
 #' @param tergmLite Logical indicating usage of either \code{tergm}
 #'        (\code{tergmLite = FALSE}), or \code{tergmLite}
 #'        (\code{tergmLite = TRUE}). Default of \code{FALSE}.
+#' @param cumulative.edgelist If \code{TRUE}, calculates a cumulative edgelist
+#'        within the network simulation module. This is used when tergmLite is
+#'        used and the entire networkDynamic object is not used.
+#' @param truncate.el.cuml Number of time steps of the cumulative edgelist to
+#'        retain. See help file for \code{\link{update_cumulative_edgelist}} for
+#'        options.
 #' @param attr.rules A list containing the  rules for setting the attributes of
 #'        incoming nodes, with one list element per attribute to be set (see
 #'        details below).
@@ -798,6 +804,8 @@ control.net <- function(type,
                         ncores = 1,
                         resimulate.network = FALSE,
                         tergmLite = FALSE,
+                        cumulative.edgelist = FALSE,
+                        truncate.el.cuml = 0,
                         attr.rules,
                         epi.by,
                         initialize.FUN = initialize.net,

--- a/R/net.mod.nwupdate.R
+++ b/R/net.mod.nwupdate.R
@@ -2,7 +2,7 @@
 #' @title Dynamic Network Updates
 #'
 #' @description This function handles all calls to the network object contained
-#'              on the master dat object handled in \code{netsim}..
+#'              on the master dat object handled in \code{netsim}.
 #'
 #' @param dat Master list object containing a full \code{networkDynamic} object
 #'        or networkLite edgelist (if using tergmLite), and other initialization
@@ -109,11 +109,11 @@ nwupdate.net <- function(dat, at) {
   }
 
   # Cummulative edgelist
-  if (!is.null(cumulative.edgelist) && cumulative.edgelist) {
+  if (!is.null(cumulative.edgelist) && cumulative.edgelist == TRUE) {
 
     truncate.el.cuml <- get_control(
       dat, "truncate.el.cuml", override.null.error = TRUE)
-    truncate.el.cuml <- if (is.null(truncate.el.cuml)) Inf else truncate.el.cuml
+    truncate.el.cuml <- if (is.null(truncate.el.cuml)) 1 else truncate.el.cuml
 
     for (network in seq_along(dat[["nwparam"]])) {
       dat <- update_cumulative_edgelist(dat, network, truncate.el.cuml)

--- a/man/control.net.Rd
+++ b/man/control.net.Rd
@@ -12,6 +12,8 @@ control.net(
   ncores = 1,
   resimulate.network = FALSE,
   tergmLite = FALSE,
+  cumulative.edgelist = FALSE,
+  truncate.el.cuml = 0,
   attr.rules,
   epi.by,
   initialize.FUN = initialize.net,
@@ -67,6 +69,14 @@ impact the network structure (e.g., vital dynamics).}
 \item{tergmLite}{Logical indicating usage of either \code{tergm}
 (\code{tergmLite = FALSE}), or \code{tergmLite}
 (\code{tergmLite = TRUE}). Default of \code{FALSE}.}
+
+\item{cumulative.edgelist}{If \code{TRUE}, calculates a cumulative edgelist
+within the network simulation module. This is used when tergmLite is
+used and the entire networkDynamic object is not used.}
+
+\item{truncate.el.cuml}{Number of time steps of the cumulative edgelist to
+retain. See help file for \code{\link{update_cumulative_edgelist}} for
+options.}
 
 \item{attr.rules}{A list containing the  rules for setting the attributes of
 incoming nodes, with one list element per attribute to be set (see

--- a/man/get_partners.Rd
+++ b/man/get_partners.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/el_cuml.R
 \name{get_partners}
 \alias{get_partners}
-\title{Get the Previous Partners of a Set of Indexes}
+\title{Get the Previous Partners of a Set of Index Patients}
 \usage{
 get_partners(
   dat,
@@ -13,18 +13,18 @@ get_partners(
 )
 }
 \arguments{
-\item{dat}{a Master list object of network models}
+\item{dat}{a Master list object for \code{netsim}.}
 
-\item{index_posit_ids}{the positional IDs of the indexes of interest}
+\item{index_posit_ids}{The positional IDs of the indexes of interest.}
 
 \item{networks}{the indexes of the networks to extract the partnerships from.
 If NULL (default) extract from all networks.}
 
-\item{max.age}{after how many steps a partnershipl that is no longer active
-should be removed from the results (default = Inf)}
+\item{max.age}{after how many steps a partnership that is no longer active
+should be removed from the results (default = Inf).}
 
-\item{only.active}{should the inactive partners be removed from the results
-(default = FALSE)}
+\item{only.active}{should inactive partners be removed from the results
+(default = FALSE).}
 }
 \value{
 a \code{data.frame} with 5 columns:
@@ -34,5 +34,5 @@ a \code{data.frame} with 5 columns:
          the partnership is.
 }
 \description{
-Get the Previous Partners of a Set of Indexes
+Get the Previous Partners of a Set of Index Patients
 }

--- a/man/nwupdate.net.Rd
+++ b/man/nwupdate.net.Rd
@@ -15,5 +15,5 @@ information passed from \code{\link{netsim}}.}
 }
 \description{
 This function handles all calls to the network object contained
-             on the master dat object handled in \code{netsim}..
+             on the master dat object handled in \code{netsim}.
 }

--- a/man/update_cumulative_edgelist.Rd
+++ b/man/update_cumulative_edgelist.Rd
@@ -4,7 +4,7 @@
 \alias{update_cumulative_edgelist}
 \title{Update a Cumulative Edgelist of the Specified Network}
 \usage{
-update_cumulative_edgelist(dat, network, truncate = Inf)
+update_cumulative_edgelist(dat, network, truncate = 0)
 }
 \arguments{
 \item{dat}{a Master list object of network models}
@@ -23,11 +23,11 @@ Update a Cumulative Edgelist of the Specified Network
 }
 \section{Truncation}{
 
-To avoid storing a cumulative edgelist to long, the `truncate`
-parameter defines a number of steps after which an edge that is no longer
-active is truncated out of the cummulative edgelist. When `truncate == Inf`
-(default), no edge is ever removed. When `truncate == 0`, only the active
-edges are kept. You may want this behavior to keep track of the active edges
-start step.
+To avoid storing a cumulative edgelist too long, the `truncate` parameter
+defines a number of steps after which an edge that is no longer active is
+truncated out of the cumulative edgelist. When `truncate == Inf` (default),
+no edges are ever removed. When `truncate == 0`, only the active edges are
+kept. You may want this behavior to keep track of the active edges start
+step.
 }
 


### PR DESCRIPTION
This changes the default of cumulative edgelist storage to FALSE, and the default truncation to 0 (current edges only). Additionally, I added cumulative.edgelist and truncate.el.cuml as explicit args in control.net. 

@AdrienLeGuillou Could you check this PR?