### PR TITLE
Fix empty positids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+library/
+local/
+cellar/
+lock/
+python/
+staging/
 .Rproj.user
 .Rhistory
 .RData

--- a/R/net.accessor.R
+++ b/R/net.accessor.R
@@ -189,7 +189,9 @@ set_attr <- function(dat, item, value, posit_ids = NULL,
           "of nodes in the network")
       }
     } else if (is.numeric(posit_ids)) {
-      if (any(posit_ids > length(dat[["attr"]][[item]]))) {
+      if (length(posit_ids) == 0) {
+        return(dat)
+      } else if (any(posit_ids > length(dat[["attr"]][[item]]))) {
         stop("Some (numeric) `posit_ids` are larger than the number of nodes ",
           " in the network")
       }

--- a/R/net.accessor.R
+++ b/R/net.accessor.R
@@ -135,7 +135,8 @@ get_attr <- function(dat, item, posit_ids = NULL, override.null.error = FALSE) {
                "number of nodes in the network")
         }
       } else if (is.numeric(posit_ids)) {
-        if (any(posit_ids > length(dat[["attr"]][[item]]))) {
+        if (length(posit_ids > 0) &&
+            any(posit_ids > length(dat[["attr"]][[item]]))) {
           stop("Some (numeric) `posit_ids` are larger than the number of ",
                "nodes in the network")
         }


### PR DESCRIPTION
this PR prevents an error from occurring when passing an empty numeric vector as the `posit_ids` arguments of `set_attr` and `get_attr`

Now `set_attr` will return an unmodified `dat` object in this case. Similar to base R behavior:

``` 
x <- 1:10
x[numeric(0)] <- 2
x
#> [1]  1  2  3  4  5  6  7  8  9 10
```

and `get_attr` will return an empty vector of the right type. As if we called:

```
dat$attr$target_attr[numeric(0)]
```

These behavior allows the module author to work with vector of IDs without checking if they are empty or not