### PR TITLE
nonstochastic netsim plots

### DIFF
--- a/R/merge.R
+++ b/R/merge.R
@@ -276,6 +276,8 @@ merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
     }
   }
 
-
+  ## whether or not we're saving them...
+  z$diss.stats <- c(z$diss.stats, y$diss.stats)
+  
   return(z)
 }

--- a/R/merge.R
+++ b/R/merge.R
@@ -118,6 +118,8 @@ merge.icm <- function(x, y, ...) {
 #'        params (in \code{\link{param.net}}) or controls (passed in
 #'        \code{\link{control.net}}) an error will prevent the merge. Use
 #'        \code{FALSE} to override that check.
+#' @param keep.diss.stats If \code{TRUE}, keep \code{diss.stats} from the 
+#'        original \code{x} and \code{y} objects.
 #' @param ...  Additional merge arguments (not currently used).
 #'
 #' @details
@@ -167,7 +169,8 @@ merge.icm <- function(x, y, ...) {
 #'
 merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
                          keep.nwstats = TRUE, keep.summary.stats = TRUE,
-                         keep.other = TRUE, param.error = TRUE, ...) {
+                         keep.other = TRUE, param.error = TRUE, 
+                         keep.diss.stats = TRUE, ...) {
 
   ## Check structure
   if (length(x) != length(y) || !identical(names(x), names(y))) {
@@ -276,8 +279,12 @@ merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
     }
   }
 
-  ## whether or not we're saving them...
-  z$diss.stats <- c(z$diss.stats, y$diss.stats)
+  if (keep.diss.stats == TRUE && !is.null(x$diss.stats) && 
+      !is.null(y$diss.stats)) {
+    z$diss.stats <- c(x$diss.stats, y$diss.stats)
+  } else {
+    z$diss.stats <- NULL
+  }
   
   return(z)
 }

--- a/R/merge.R
+++ b/R/merge.R
@@ -282,7 +282,7 @@ merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
   if (keep.diss.stats == TRUE && !is.null(x$diss.stats) && 
       !is.null(y$diss.stats)) {
     z$diss.stats <- c(x$diss.stats, y$diss.stats)
-    names(z$diss.stats) <- paste0("sim", seq_len(z$control$nsims))
+    names(z$diss.stats) <- c(names(x$diss.stats), paste0("sim", new.range))
   } else {
     z$diss.stats <- NULL
   }

--- a/R/merge.R
+++ b/R/merge.R
@@ -282,6 +282,7 @@ merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
   if (keep.diss.stats == TRUE && !is.null(x$diss.stats) && 
       !is.null(y$diss.stats)) {
     z$diss.stats <- c(x$diss.stats, y$diss.stats)
+    names(z$diss.stats) <- paste0("sim", seq_len(z$control$nsims))
   } else {
     z$diss.stats <- NULL
   }

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -790,6 +790,10 @@ init.net <- function(i.num, r.num, i.num.g2, r.num.g2,
 #' @param set.control.stergm Deprecated control argument of class
 #'        \code{control.simulate.network}; use \code{set.control.tergm}
 #'        instead.
+#' @param save.diss.stats If \code{TRUE}, \code{netsim} will compute and save
+#'        duration/dissolution statistics for plotting and printing, provided
+#'        \code{save.network} is \code{TRUE}, \code{tergmLite} is \code{FALSE},
+#'        and the dissolution model is homogeneous.
 #' @param ... Additional control settings passed to model.
 #'
 #' @details
@@ -914,6 +918,7 @@ control.net <- function(type,
                           MCMC.burnin = 2e5),
                         set.control.stergm = NULL,
                         set.control.tergm = control.simulate.formula.tergm(),
+                        save.diss.stats = TRUE,
                         ...) {
   if (!missing(set.control.stergm)) {
     warning("set.control.stergm is deprecated and will be removed in a future
@@ -1030,7 +1035,7 @@ control.net <- function(type,
             call. = FALSE)
     p[["resimulate.network"]] <- TRUE
   }
-
+  
   ## Output
   p <- set.control.class("control.net", p)
   return(p)

--- a/R/plot.R
+++ b/R/plot.R
@@ -2079,7 +2079,8 @@ plot.netsim <- function(x, type = "epi", y, popfrac = FALSE, sim.lines = FALSE,
       } else {
         stop("cannot produce duration/dissolution plot from `netsim` object ",
              "unless `save.diss.stats` is `TRUE`, `save.network` is `TRUE`, ",
-             "`tergmLite` is `FALSE`, and dissolution model is edges-only")
+             "`tergmLite` is `FALSE`, `keep.diss.stats` is `TRUE` (if ",
+             "merging), and dissolution model is edges-only")
       }
       
       if (type == "duration") {

--- a/R/plot.R
+++ b/R/plot.R
@@ -2064,36 +2064,21 @@ plot.netsim <- function(x, type = "epi", y, popfrac = FALSE, sim.lines = FALSE,
       colnames(stats_table) <- c("Target", "Sim Mean")
       rownames(stats_table) <- nmstats
     } else {
-      ## duration/dissolution plot
-      if (type == "duration" && isTRUE(duration.imputed)) {
-        warning("plotting duration statistics from a `netsim` object with",
-                " `duration.imputed = TRUE` will produce stochastic results",
-                " as durational corrections for onset-censored edges are",
-                " imputed randomly each time; this behavior may be changed in",
-                " the future")
-      }
-      
-      if (isTRUE(x$control$save.network) &&
+      ## duration/dissolution plot      
+      if (isTRUE(x$control$save.diss.stats) &&
+          isTRUE(x$control$save.network) &&
           isFALSE(x$control$tergmLite) &&
-          isTRUE(x$nwparam[[network]]$coef.diss$diss.model.type == "edgesonly")) {
-        diag.sim <- lapply(sims, get_network, network = network, x = x)
-        
-        dstats <- make_dissolution_stats( 
-          lapply(diag.sim, 
-                 function(nwd) { 
-                   toggles_to_diss_stats(tedgelist_to_toggles(as.data.frame(nwd)), 
-                                         x$nwparam[[network]]$coef.diss, 
-                                         x$control$nsteps, 
-                                         nwd) 
-                 }),
+          isTRUE(x$nwparam[[network]]$coef.diss$diss.model.type == "edgesonly")) {        
+        dstats <- make_dissolution_stats(
+          lapply(sims, function(sim) x$diss.stats[[sim]][[network]]),
           x$nwparam[[network]]$coef.diss,
           x$control$nsteps,
           verbose = FALSE
         )
       } else {
         stop("cannot produce duration/dissolution plot from `netsim` object ",
-             "unless `save.network` is `TRUE`, `tergmLite` is `FALSE`, and ",
-             "dissolution model is edges-only")
+             "unless `save.diss.stats` is `TRUE`, `save.network` is `TRUE`, ",
+             "`tergmLite` is `FALSE`, and dissolution model is edges-only")
       }
       
       if (type == "duration") {

--- a/R/plot.R
+++ b/R/plot.R
@@ -2068,6 +2068,7 @@ plot.netsim <- function(x, type = "epi", y, popfrac = FALSE, sim.lines = FALSE,
       if (isTRUE(x$control$save.diss.stats) &&
           isTRUE(x$control$save.network) &&
           isFALSE(x$control$tergmLite) &&
+          isFALSE(is.null(x$diss.stats)) &&
           isTRUE(x$nwparam[[network]]$coef.diss$diss.model.type == "edgesonly")) {        
         dstats <- make_dissolution_stats(
           lapply(sims, function(sim) x$diss.stats[[sim]][[network]]),

--- a/R/print.r
+++ b/R/print.r
@@ -215,7 +215,10 @@ print.netsim <- function(x, nwstats = TRUE, digits = 3, network = 1, ...) {
     }
   }
   if (!is.null(x$control$save.other)) {
-    cat("\nOther Elements:", x$control$save.other)
+    names_present <- intersect(x$control$save.other, names(x))
+    if (length(names_present) > 0) {
+      cat("\nOther Elements:", names_present)
+    }
   }
   cat("")
 

--- a/R/print.r
+++ b/R/print.r
@@ -249,6 +249,7 @@ print.netsim <- function(x, nwstats = TRUE, digits = 3, network = 1, ...) {
     if (x$control$save.diss.stats &&
         x$control$save.network &&
         ! x$control$tergmLite &&
+        ! is.null(x$diss.stats) &&
         x$nwparam[[network]]$coef.diss$dissolution == ~ offset(edges)) {
 
       dissolution.stats <- make_dissolution_stats(

--- a/R/print.r
+++ b/R/print.r
@@ -271,6 +271,7 @@ print.netsim <- function(x, nwstats = TRUE, digits = 3, network = 1, ...) {
       cat("\n- `control$save.network == FALSE`")
       cat("\n- `control$save.diss.stats == FALSE`")
       cat("\n- dissolution formula is not `~ offset(edges)`")
+      cat("\n- `keep.diss.stats == FALSE` (if merging)")
       cat("\n")
     }
   }

--- a/R/print.r
+++ b/R/print.r
@@ -264,10 +264,6 @@ print.netsim <- function(x, nwstats = TRUE, digits = 3, network = 1, ...) {
       
       print_nwstats_table(dissolution.stats$stats.table.dissolution, digits)
 
-      if (x$nwparam[[network]]$coef.diss$diss.model.type == "hetero") {
-        cat("----------------------- \n")
-        cat("* Heterogeneous dissolution model results averaged over")
-      }
     } else {
       cat("Not available when:")
       cat("\n- `control$tergmLite == TRUE`")

--- a/R/print.r
+++ b/R/print.r
@@ -246,27 +246,18 @@ print.netsim <- function(x, nwstats = TRUE, digits = 3, network = 1, ...) {
     cat("\nDissolution Diagnostics")
     cat("\n----------------------- \n")
 
-    if (x$control$save.network &&
+    if (x$control$save.diss.stats &&
+        x$control$save.network &&
         ! x$control$tergmLite &&
         x$nwparam[[network]]$coef.diss$dissolution == ~ offset(edges)) {
-      diag.sim <- lapply(
-        seq_len(x$control$nsims),
-        get_network, network = network, x = x
-      )
-      
-      dissolution.stats <- make_dissolution_stats( 
-        lapply(diag.sim, 
-               function(nwd) { 
-                 toggles_to_diss_stats(tedgelist_to_toggles(as.data.frame(nwd)), 
-                                       x$nwparam[[network]]$coef.diss, 
-                                       x$control$nsteps, 
-                                       nwd) 
-               }),
+
+      dissolution.stats <- make_dissolution_stats(
+        lapply(seq_len(x$control$nsims), function(sim) x$diss.stats[[sim]][[network]]),
         x$nwparam[[network]]$coef.diss,
         x$control$nsteps,
         verbose = FALSE
       )
-
+      
       print_nwstats_table(dissolution.stats$stats.table.dissolution, digits)
 
       if (x$nwparam[[network]]$coef.diss$diss.model.type == "hetero") {
@@ -277,6 +268,7 @@ print.netsim <- function(x, nwstats = TRUE, digits = 3, network = 1, ...) {
       cat("Not available when:")
       cat("\n- `control$tergmLite == TRUE`")
       cat("\n- `control$save.network == FALSE`")
+      cat("\n- `control$save.diss.stats == FALSE`")
       cat("\n- dissolution formula is not `~ offset(edges)`")
       cat("\n")
     }

--- a/R/saveout.R
+++ b/R/saveout.R
@@ -359,6 +359,12 @@ saveout.net <- function(dat, s, out = NULL) {
       }
     }
 
+    if (dat$control$save.diss.stats == TRUE &&
+        dat$control$save.network == TRUE &&
+        dat$control$tergmLite == FALSE) {
+      names(out$diss.stats) <- simnames
+    }
+
     # Remove functions from control list
     ftodel <- grep(".FUN", names(out$control), value = TRUE)
     out$control[ftodel] <- NULL

--- a/R/saveout.R
+++ b/R/saveout.R
@@ -225,6 +225,23 @@ saveout.net <- function(dat, s, out = NULL) {
         out[[el.name]] <- list(dat[[el.name]])
       }
     }
+    
+    if (dat$control$save.diss.stats == TRUE &&
+        dat$control$save.network == TRUE &&
+        dat$control$tergmLite == FALSE) {
+      
+      ## for each simulated network, if dissolution model is edges-only, compute diss stats
+      out$diss.stats <- list(lapply(seq_len(num.nw), function(network) {
+        if (dat$nwparam[[network]]$coef.diss$diss.model.type == "edgesonly") {
+          toggles_to_diss_stats(tedgelist_to_toggles(as.data.frame(dat$nw[[network]])), 
+                                dat$nwparam[[network]]$coef.diss, 
+                                dat$control$nsteps, 
+                                dat$nw[[network]])
+        } else {
+          NULL
+        }
+      }))
+    }
   }
 
   if (s > 1) {
@@ -287,6 +304,24 @@ saveout.net <- function(dat, s, out = NULL) {
         out[[el.name]][[s]] <- dat[[el.name]]
       }
     }
+
+    if (dat$control$save.diss.stats == TRUE &&
+        dat$control$save.network == TRUE &&
+        dat$control$tergmLite == FALSE) {
+      
+      ## for each simulated network, if dissolution model is edges-only, compute diss stats
+      out$diss.stats[[s]] <- lapply(seq_len(num.nw), function(network) {
+        if (dat$nwparam[[network]]$coef.diss$diss.model.type == "edgesonly") {
+          toggles_to_diss_stats(tedgelist_to_toggles(as.data.frame(dat$nw[[network]])), 
+                                dat$nwparam[[network]]$coef.diss, 
+                                dat$control$nsteps, 
+                                dat$nw[[network]])
+        } else {
+          NULL
+        }
+      })
+    }
+
   }
 
   ## Final processing

--- a/man/control.net.Rd
+++ b/man/control.net.Rd
@@ -39,6 +39,7 @@ control.net(
   set.control.ergm = control.simulate.formula(MCMC.burnin = 2e+05),
   set.control.stergm = NULL,
   set.control.tergm = control.simulate.formula.tergm(),
+  save.diss.stats = TRUE,
   ...
 )
 }
@@ -178,6 +179,11 @@ instead.}
 \code{simulate_formula.network}. See the help file for
 \code{\link{netdx}} for details and examples on specifying this
 parameter.}
+
+\item{save.diss.stats}{If \code{TRUE}, \code{netsim} will compute and save
+duration/dissolution statistics for plotting and printing, provided
+\code{save.network} is \code{TRUE}, \code{tergmLite} is \code{FALSE},
+and the dissolution model is homogeneous.}
 
 \item{...}{Additional control settings passed to model.}
 }

--- a/man/merge.netsim.Rd
+++ b/man/merge.netsim.Rd
@@ -13,6 +13,7 @@
   keep.summary.stats = TRUE,
   keep.other = TRUE,
   param.error = TRUE,
+  keep.diss.stats = TRUE,
   ...
 )
 }
@@ -45,6 +46,9 @@ original \code{x} and \code{y} elements.}
 params (in \code{\link{param.net}}) or controls (passed in
 \code{\link{control.net}}) an error will prevent the merge. Use
 \code{FALSE} to override that check.}
+
+\item{keep.diss.stats}{If \code{TRUE}, keep \code{diss.stats} from the 
+original \code{x} and \code{y} objects.}
 
 \item{...}{Additional merge arguments (not currently used).}
 }

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -119,3 +119,34 @@ test_that("merge works for open sims saving nw stats", {
   expect_true(length(unique(nws$sim)) == 2)
 
 })
+
+test_that("merge and print work as expected for save.other", {
+  nw <- network_initialize(n = 100)
+  formation <- ~edges
+  target.stats <- 50
+  coef.diss <- dissolution_coefs(dissolution = ~offset(edges), duration = 10)
+  est <- netest(nw, formation, target.stats, coef.diss, verbose = FALSE)
+
+  # Epidemic model
+  param <- param.net(inf.prob = 0.3)
+  init <- init.net(i.num = 10)
+  control <- control.net(type = "SI", nsteps = 5, nsims = 2, verbose = FALSE, 
+                         tergmLite = TRUE, resimulate.network = TRUE,
+                         save.other = c("attr", "el"))
+  mod <- netsim(est, param, init, control)
+
+  print(mod)
+  expect_output(print(mod), "Other Elements: attr el")
+  expect_equal(length(mod[["attr"]]), 2)
+  expect_equal(length(mod[["el"]]), 2)
+  
+  mod2 <- merge(mod, mod)
+  expect_output(print(mod2), "Other Elements: attr el")
+  expect_equal(length(mod2[["attr"]]), 4)
+  expect_equal(length(mod2[["el"]]), 4)
+  
+  mod3 <- merge(mod, mod, keep.other = FALSE)
+  expect_error(expect_output(print(mod3), "Other Elements"))
+  expect_true(is.null(mod3[["attr"]]))
+  expect_true(is.null(mod3[["el"]]))
+})

--- a/tests/testthat/test-netsim.R
+++ b/tests/testthat/test-netsim.R
@@ -195,15 +195,15 @@ test_that("netsim diss.stats", {
   print(mod)
   expect_output(print(mod), "Dissolution Diagnostics.*Sim Mean")
   expect_error(expect_output(print(mod), "Not available when:"))
-  expect_true(!is.null(mod$diss.stats))
+  expect_equal(length(mod[["diss.stats"]]), 2)
   
   mod2 <- merge(mod, mod)
   expect_output(print(mod2), "Dissolution Diagnostics.*Sim Mean")
   expect_error(expect_output(print(mod2), "Not available when:"))
-  expect_true(!is.null(mod2$diss.stats))
+  expect_equal(length(mod2[["diss.stats"]]), 4)
   
   mod3 <- merge(mod, mod, keep.diss.stats = FALSE)
   expect_error(expect_output(print(mod3), "Dissolution Diagnostics.*Sim Mean"))
   expect_output(print(mod3), "Not available when:")
-  expect_true(is.null(mod3$diss.stats))
+  expect_true(is.null(mod3[["diss.stats"]]))
 })

--- a/tests/testthat/test-netsim.R
+++ b/tests/testthat/test-netsim.R
@@ -178,3 +178,32 @@ test_that("non-nested EDA works in netsim", {
   dxs <- netdx(est, nsteps = 2, nsims = 2, dynamic = FALSE)
   sim <- netsim(est, param, init, control)
 })
+
+test_that("netsim diss.stats", {
+  nw <- network_initialize(n = 100)
+  formation <- ~edges
+  target.stats <- 50
+  coef.diss <- dissolution_coefs(dissolution = ~offset(edges), duration = 10)
+  est <- netest(nw, formation, target.stats, coef.diss, verbose = FALSE)
+
+  # Epidemic model
+  param <- param.net(inf.prob = 0.3)
+  init <- init.net(i.num = 10)
+  control <- control.net(type = "SI", nsteps = 5, nsims = 2, verbose = FALSE)
+  mod <- netsim(est, param, init, control)
+
+  print(mod)
+  expect_output(print(mod), "Dissolution Diagnostics.*Sim Mean")
+  expect_error(expect_output(print(mod), "Not available when:"))
+  expect_true(!is.null(mod$diss.stats))
+  
+  mod2 <- merge(mod, mod)
+  expect_output(print(mod2), "Dissolution Diagnostics.*Sim Mean")
+  expect_error(expect_output(print(mod2), "Not available when:"))
+  expect_true(!is.null(mod2$diss.stats))
+  
+  mod3 <- merge(mod, mod, keep.diss.stats = FALSE)
+  expect_error(expect_output(print(mod3), "Dissolution Diagnostics.*Sim Mean"))
+  expect_output(print(mod3), "Not available when:")
+  expect_true(is.null(mod3$diss.stats))
+})


### PR DESCRIPTION
stacked on #702

closes #713, #719

(optionally) stores diss stats on returned netsim object for later plotting, printing

also tweaks a couple of things to more consistently handle netsim fields dropped in merge (cf #719)


