### PR TITLE
netest default controls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - Formula-style simulations are used consistently for both `ergm` and `tergm` simulation, requiring control arguments of class `control.simulate.formula` and `control.simulate.formula.tergm`.
 - `ndtv` is added to "Suggests" (again) and `plot.transmat` now accepts the `transmissionTimeline` in the `style` argument (again).
 - Systematic review and improvement of documentation across the package.
+- `netest` and `netdx` now have default control arguments following R's default argument mechanism.
 
 
 ## EpiModel 2.2.1

--- a/R/netest.R
+++ b/R/netest.R
@@ -143,7 +143,9 @@
 #'
 netest <- function(nw, formation, target.stats, coef.diss, constraints,
                    coef.form = NULL, edapprox = TRUE,
-                   set.control.ergm, set.control.stergm, set.control.tergm,
+                   set.control.ergm = control.ergm(), 
+                   set.control.stergm = control.stergm(), 
+                   set.control.tergm = control.tergm(),
                    verbose = FALSE, nested.edapprox = TRUE, ...) {
 
   if (!missing(set.control.stergm)) {
@@ -186,10 +188,6 @@ netest <- function(nw, formation, target.stats, coef.diss, constraints,
                     control = set.control.stergm,
                     verbose = verbose)
     } else {
-      if (missing(set.control.tergm)) {
-        set.control.tergm <- control.tergm()
-      }
-
       fit <- tergm(nw ~ Form(formation) + Persist(dissolution),
                    targets = "formation",
                    target.stats = target.stats,
@@ -223,10 +221,6 @@ netest <- function(nw, formation, target.stats, coef.diss, constraints,
     out$formula <- fit$formula
 
   } else {
-
-    if (missing(set.control.ergm)) {
-      set.control.ergm <- control.ergm()
-    }
 
     formation.nw <- nonsimp_update.formula(formation, nw ~ ., from.new = "nw")
 

--- a/man/netest.Rd
+++ b/man/netest.Rd
@@ -12,9 +12,9 @@ netest(
   constraints,
   coef.form = NULL,
   edapprox = TRUE,
-  set.control.ergm,
-  set.control.stergm,
-  set.control.tergm,
+  set.control.ergm = control.ergm(),
+  set.control.stergm = control.stergm(),
+  set.control.tergm = control.tergm(),
   verbose = FALSE,
   nested.edapprox = TRUE,
   ...


### PR DESCRIPTION
I previously added default control arguments to `netdx`, in part to illustrate the required control classes.  This does the same for `netest`, and updates the NEWS file.