### PR TITLE
Update lint-package.yml

### DIFF
--- a/.github/workflows/lint-package.yml
+++ b/.github/workflows/lint-package.yml
@@ -1,4 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -7,6 +9,7 @@ on:
     branches: [main, master]
 
 name: lint-project
+name: lint
 
 jobs:
   lint:
@@ -15,15 +18,17 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: lintr
+          extra-packages: lintr,pkgbuild,pkgload
+          extra-packages: any::lintr, local::.
+          needs: lint
 
       - name: Lint
+        run: pkgload::load_all(); lintr::lint_package()
         run: lintr::lint_package()
         shell: Rscript {0}


### PR DESCRIPTION
`lintr` needs to be aware of all the functions from the package to avoid the `unknown global function` warning. 
This PR updates the `lintr` action [as described in this PR](https://github.com/r-lib/actions/pull/558)

It should fix [these warnings](https://github.com/EpiModel/EpiModel/runs/7416569905?check_suite_focus=true#step:5:15) in #751