### PR TITLE
create a generic padded_vector function

### DIFF
--- a/R/net.accessor.R
+++ b/R/net.accessor.R
@@ -311,7 +311,7 @@ add_epi <- function(dat, item) {
     stop("Cannot create the epi output, ", item, ": exists already")
   }
 
-  dat[["epi"]][[item]] <- rep(NA, dat[["control"]][["nsteps"]])
+  dat[["epi"]][[item]] <- padded_vector(NA_real_, dat[["control"]][["nsteps"]])
 
   return(dat)
 }
@@ -327,12 +327,12 @@ set_epi <- function(dat, item, at,  value) {
     dat <- add_epi(dat, item)
   }
 
+  # ensure that the vector is of size `nsteps`, right padded with NA
   if (at > length(dat[["epi"]][[item]])) {
-
-      dat[["epi"]][[item]] <- c(
-        dat[["epi"]][[item]],
-        rep(NA, dat[["control"]][["nsteps"]] - length(dat[["epi"]][[item]]))
-      )
+    dat[["epi"]][[item]] <- padded_vector(
+      dat[["epi"]][[item]],
+      dat[["control"]][["nsteps"]]
+    )
   }
 
   dat[["epi"]][[item]][at] <- value
@@ -677,4 +677,15 @@ is_active_unique_ids <- function(dat, unique_ids) {
 is_active_posit_ids <- function(dat, posit_ids) {
   active <- get_attr(dat, "active")
   return(active[posit_ids] %in% 1)
+}
+
+# Make a vector of size `size` by padding an `orig` element
+# pad with NULL if `orig` is a `list` and with `NA` otherwise
+padded_vector <- function(orig, size) {
+  if (is.list(orig)) {
+    out <- c(orig, vector(mode = "list", size - length(orig)))
+  } else {
+    out <- c(orig, rep(NA, size - length(orig)))
+  }
+  return(out)
 }

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -75,7 +75,7 @@ test_that("`dat` getters and setter", {
 
   ## Epi tests
   dat <- add_epi(dat, "i")
-  expect_equal(dat$epi$i, rep(NA, dat$control$nsteps))
+  expect_equal(dat$epi$i, rep(NA_real_, dat$control$nsteps))
 
   expect_error(set_epi(dat, "i", c(1, 4), 4))
 


### PR DESCRIPTION
refactor `set_epi` and `add_epi` to use a generic `padded_vector` function that can be used by `nwstats` or `transmat` for instance.
Also put `epi` by default to `NA_real_` as they are more often numeric than logical