### PR TITLE
remove the `call.` argument to `message`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,9 @@
 ### BUG FIXES
 
 - Fix `get_sims` not properly subsetting `el.cuml` and `_last_unique_id`.
-- Fix parallel memory leak in `netsim`. 
+- Fix parallel memory leak in `netsim`.
 - Rework the network resimulation module to allow for working with observed network data. See this [EpiModel Gallery Example](https://github.com/EpiModel/EpiModel-Gallery/tree/main/2018-08-ObservedNetworkData).
+- Fix error message for tergmLite/resimulate.network collision
 
 ### OTHER
 

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -960,8 +960,7 @@ control.net <- function(type,
     p[["save.network"]] <- FALSE
   }
   if (p[["tergmLite"]] == TRUE && p[["resimulate.network"]] == FALSE) {
-    message("Because tergmLite = TRUE, resetting resimulate.network = TRUE",
-            call. = FALSE)
+    message("Because tergmLite = TRUE, resetting resimulate.network = TRUE")
     p[["resimulate.network"]] <- TRUE
   }
 


### PR DESCRIPTION
in `control.net` `message` is called with a `call.` argument. As it is not a named argument to `message`, the value is concatenated to the message string.

fixes #780 