### PR TITLE
fix rng and scenarios tests

### DIFF
--- a/R/net.scenarios.R
+++ b/R/net.scenarios.R
@@ -128,12 +128,12 @@ use_scenario <- function(param, scenario) {
 #' Helper function validating the format of a `scenarios.df`
 #' @noRd
 check_scenarios_df <- function(scenarios.df) {
-  checks <- c(
-    all(c(".scenario.id", ".at") %in% names(scenarios.df)),
+  checks <-
+    all(c(".scenario.id", ".at") %in% names(scenarios.df)) &&
+    is.numeric(scenarios.df[[".at"]]) &&
     all(as.integer(scenarios.df[[".at"]]) == scenarios.df[[".at"]])
-  )
 
-  if (! all(checks)) {
+  if (!checks) {
     stop(
       "A `data.frame` of scenarios must have a '.scenario.id' column \n",
       "and a '.at' column containing integers."

--- a/tests/testthat/test-random-params.R
+++ b/tests/testthat/test-random-params.R
@@ -51,7 +51,7 @@ test_that("Random parameters generators", {
   )
 
   randoms <- c(my_randoms, list(param.random.set = correlated_params))
-  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
+  param <- param.net(inf.prob = 0.3, random.params = randoms)
   expect_silent(generate_random_params(param))
 
   # duplicated `act.rate` random definition
@@ -61,7 +61,9 @@ test_that("Random parameters generators", {
     "param.set.2_1", "param.set.2_2", "param.set.2_3"
   )
   randoms <- c(my_randoms, list(param.random.set = correlated_params))
-  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
+  expect_warning(
+    param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
+  )
   expect_warning(generate_random_params(param))
 
   # malformed name "param_set.1_1"
@@ -71,12 +73,12 @@ test_that("Random parameters generators", {
     "param.set.2_1", "param.set.2_2", "param.set.2_3"
   )
   randoms <- c(my_randoms, list(param.random.set = correlated_params))
-  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
+  param <- param.net(inf.prob = 0.3, random.params = randoms)
   expect_error(generate_random_params(param))
 
   # param.random.set not a data.frame
   randoms <- c(my_randoms, list(param.random.set = list()))
-  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
+  param <- param.net(inf.prob = 0.3, random.params = randoms)
   expect_error(generate_random_params(param))
 })
 


### PR DESCRIPTION
- some of the rng params test where malformed they were adding duplicated params where they shouldn't. Triggering warnings that are tested elsewhere
- the check_scenario_df function was letting a warning pass due to poor ordering of the checks