### PR TITLE
Prevent errors when missing elements are saved

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Use `unflatten_params` in `generate_random_params` instead of bespoke code.
 - Standardize and speed up the summary calculations and plotting functionality for `netdx` and `netsim` objects.
 - Streamline unit tests for testing on CRAN.
+- Change in the inner behavior of `saveout.net`: missing elements on some simulations now produce a warning instead of an error. Additionally, elements passed to `save.other` that are not present in the final object are skipped silently instead of producing an error.
 
 
 ## EpiModel 2.3.0

--- a/R/saveout.R
+++ b/R/saveout.R
@@ -335,43 +335,33 @@ saveout.net <- function(dat, s, out = NULL) {
       colnames(out$epi[[i]]) <- simnames
     }
 
-    if (length(out$el.cuml) > 0)
-      names(out$el.cuml) <- simnames
-
-    if (length(out[["_last_unique_id"]]) > 0)
-      names(out[["_last_unique_id"]]) <- simnames
-
-    if (length(out$attr.history) > 0)
-      names(out$attr.history) <- simnames
-
-    if (length(out$.records) > 0)
-    names(out$raw.records) <- simnames
+    top_lvl_elts <- c("el.cuml", "_last_unique_id", "attr.history", ".records")
+    for (elt in top_lvl_elts) {
+      out[[elt]] <- name_saveout_elts(out[[elt]], elt, simnames)
+    }
 
     if (dat$control$save.nwstats == TRUE) {
-      names(out$stats$nwstats) <- simnames
+      out$stats$nwstats <- name_saveout_elts(
+        out$stats$nwstats, "stats$nwstats", simnames)
     }
 
     if (dat$control$save.transmat == TRUE) {
-      names(out$stats$transmat) <- simnames
+      out$stats$transmat <- name_saveout_elts(
+        out$stats$transmat, "stats$transmat", simnames)
     }
 
-    if (dat$control$tergmLite == FALSE) {
-      if (dat$control$save.network == TRUE) {
-        names(out$network) <- simnames
-      }
+    if (dat$control$tergmLite == FALSE && dat$control$save.network == TRUE) {
+      out$network <- name_saveout_elts(out$network, "network", simnames)
     }
 
     if (dat$control$save.diss.stats == TRUE &&
         dat$control$save.network == TRUE &&
         dat$control$tergmLite == FALSE) {
-      names(out$diss.stats) <- simnames
+      out$diss.stats <- name_saveout_elts(out$diss.stats, "diss.stats", simnames)
     }
 
-    if (!is.null(dat$control$save.other)) {
-      for (i in seq_along(dat$control$save.other)) {
-        el.name <- dat$control$save.other[i]
-        names(out[[el.name]]) <- simnames
-      }
+    for (el.name in dat$control$save.other) {
+      out[[el.name]] <- name_saveout_elts(out[[el.name]], el.name, simnames)
     }
 
     # Remove functions from control list
@@ -434,4 +424,15 @@ process_out.net <- function(dat_list) {
   class(out) <- "netsim"
 
   return(out)
+}
+
+name_saveout_elts <- function(elt, elt_name, simnames) {
+  if (length(elt) == length(simnames)) {
+    names(elt) <- simnames
+  } else if (length(elt) > 0) {
+    warning(
+      "The number of `", elt_name, "` is not the number of simulations.",
+      "Unable to assign each to the correct simulation.")
+  }
+  return(elt)
 }

--- a/tests/testthat/test-netsim.R
+++ b/tests/testthat/test-netsim.R
@@ -232,3 +232,24 @@ test_that("save.other sim naming", {
   mod4 <- merge(mod, mod, keep.other = FALSE)
   expect_equal(names(mod4[["nw"]]), NULL)
 })
+
+test_that("name_saveout_elts unit", {
+  simnames <- paste0("sim", 1:4)
+  elt_name <- "this_elt"
+
+  elt <- rep(list(sample(10)), 4)
+  named_elt <- expect_silent(name_saveout_elts(elt, elt_name, simnames))
+  expect_equal(names(named_elt), simnames)
+
+  # wrong size produces a warning
+  elt <- rep(list(sample(10)), 2)
+  named_elt <- expect_warning(name_saveout_elts(elt, elt_name, simnames))
+  expect_null(names(named_elt))
+  expect_equal(elt, named_elt)
+
+  # empty element returns silently
+  elt <- NULL
+  named_elt <- expect_silent(name_saveout_elts(elt, elt_name, simnames))
+  expect_null(names(named_elt))
+  expect_equal(elt, named_elt)
+})


### PR DESCRIPTION
Changes the behavior of `saveout.net` on the last sim of a batch. It now tries to rename the elements if there number match the number of simulation. In case of missmatch, a warning is produced.

addresses #790 