### PR TITLE
 Fix error where `get_attr_history` would crash on length zero PIDs 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Fix parallel memory leak in `netsim`.
 - Rework the network resimulation module to allow for working with observed network data. See this [EpiModel Gallery Example](https://github.com/EpiModel/EpiModel-Gallery/tree/main/2018-08-ObservedNetworkData).
 - Fix error message for tergmLite/resimulate.network collision
+- Fix error where `get_attr_history` would crash when some attribute history `posit_ids` argument is `integer(0)`
 
 ### OTHER
 

--- a/R/get.R
+++ b/R/get.R
@@ -630,16 +630,11 @@ get_attr_history <- function(sims) {
 
     for (a in attributes.names) {
       parts <- Filter(function(x) x[["attribute"]] == a, records)
-      parts <- lapply(parts, as.data.frame)
-      d <- do.call("rbind", parts)
+      parts <- lapply(parts, dplyr::as_tibble)
+      d <- dplyr::bind_rows(parts)
       d[["sim"]] <- simnum
-      d <- d[, c("sim", "time", "attribute", "uids", "values")]
-
-      if (is.null(dfs[[a]])) {
-        dfs[[a]] <- d
-      } else {
-        dfs[[a]] <- rbind(dfs[[a]], d)
-      }
+      d <- dplyr::select(d, "sim", "time", "attribute", "uids", "values")
+      dfs[[a]] <- dplyr::bind_rows(dfs[[a]], d)
     }
   }
 

--- a/tests/testthat/test-record.R
+++ b/tests/testthat/test-record.R
@@ -71,5 +71,7 @@ test_that("Time varying elements", {
   attr_history <- get_attr_history(mod)
   expect_is(attr_history, "list")
   expect_is(attr_history[[1]], "data.frame")
-  expect_equal(names(attr_history), c("attr_norm", "attr_unif", "attr_fix"))
+  expect_equal(
+    names(attr_history),
+    c("attr_norm", "attr_unif", "attr_fix", "attr_none"))
 })

--- a/tests/testthat/test-record.R
+++ b/tests/testthat/test-record.R
@@ -28,6 +28,15 @@ test_that("Time varying elements", {
       at
     )
 
+    # test when 0 nodes selected
+    some_nodes <- integer(0)
+    dat <- record_attr_history(
+      dat, at,
+      "attr_none",
+      some_nodes,
+      at
+    )
+
     return(dat)
   }
 


### PR DESCRIPTION
- using `dplyr::as_tibble` fixes it automatically
- addition of a specific test for the 0 length case