### PR TITLE
Fix unit tests for v2.3.2 push

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,18 +30,18 @@ Depends:
     R (>= 3.5),
     deSolve (>= 1.21),
     networkDynamic (>= 0.11.3),
-    tergm (>= 4.1.0),
-    statnet.common (>= 4.6.0)
+    tergm (>= 4.1.1),
+    statnet.common (>= 4.8.0)
 Imports:
     graphics,
     grDevices,
     stats,
     utils,
     doParallel,
-    ergm (>= 4.2.2),
+    ergm (>= 4.4.0),
     ergm.ego (>= 1.0.1),
     foreach,
-    network (>= 1.17.2),
+    network (>= 1.18.1),
     RColorBrewer,
     ape,
     lazyeval,
@@ -51,7 +51,7 @@ Imports:
     rlang,
     dplyr,
     coda,
-    networkLite
+    networkLite (>= 1.0.1)
 Suggests:
     knitr,
     ndtv,

--- a/tests/testthat/test-ergm.ego.R
+++ b/tests/testthat/test-ergm.ego.R
@@ -1,18 +1,19 @@
-context("ergm.ego")
+context("ergm.ego (All SOC)")
 
 # Test ergm.ego ---------------------------------------------------
 
 test_that("ergm and ergm.ego produce the same results in EpiModel", {
+  skip_on_cran()
   for (trim in list(FALSE, TRUE)) {
     for (ppopnw in list(FALSE, TRUE)) {
       nw <- network_initialize(n = 50)
       nw %v% "race" <- rep(1:2, length.out = 50)
       nw <- san(nw ~ edges, target.stats = c(50))
-      
+
       nwe <- egor::as.egor(nw)
-      
+
       nw[,] <- FALSE
-      
+
       set.seed(0)
       if (ppopnw == TRUE) {
         netest_ergm.ego <- netest(nwe, formation = ~edges + degree(1) + nodemix("race"),
@@ -27,43 +28,43 @@ test_that("ergm and ergm.ego produce the same results in EpiModel", {
       set.seed(0)
       netest_ergm <- netest(nw, formation = ~edges + degree(1) + nodemix("race"),
                             target.stats = netest_ergm.ego$target.stats,
-                            coef.diss = dissolution_coefs(~offset(edges), 10, 0))                          
+                            coef.diss = dissolution_coefs(~offset(edges), 10, 0))
 
       if (trim == TRUE) {
         netest_ergm <- trim_netest(netest_ergm)
         netest_ergm.ego <- trim_netest(netest_ergm.ego)
       }
-      
+
       expect_identical(netest_ergm$coef.form.crude, netest_ergm.ego$coef.form.crude)
-        
+
       set.seed(0)
-      dx_ergm <- netdx(netest_ergm, nsteps = 5, dynamic = FALSE)
+      dx_ergm <- netdx(netest_ergm, nsteps = 5, dynamic = FALSE, verbose = FALSE)
       set.seed(0)
-      dx_ergm.ego <- netdx(netest_ergm.ego, nsteps = 5, dynamic = FALSE)
-      
+      dx_ergm.ego <- netdx(netest_ergm.ego, nsteps = 5, dynamic = FALSE, verbose = FALSE)
+
       expect_identical(dx_ergm$stats, dx_ergm.ego$stats)
       expect_identical(dx_ergm$stats.table.formation, dx_ergm.ego$stats.table.formation)
-      
+
       set.seed(0)
-      dxd_ergm <- netdx(netest_ergm, nsteps = 5, dynamic = TRUE)
+      dxd_ergm <- netdx(netest_ergm, nsteps = 5, dynamic = TRUE, verbose = FALSE)
       set.seed(0)
-      dxd_ergm.ego <- netdx(netest_ergm.ego, nsteps = 5, dynamic = TRUE)
-      
+      dxd_ergm.ego <- netdx(netest_ergm.ego, nsteps = 5, dynamic = TRUE, verbose = FALSE)
+
       expect_identical(dxd_ergm$stats, dxd_ergm.ego$stats)
       expect_identical(dxd_ergm$stats.table.formation, dxd_ergm.ego$stats.table.formation)
       expect_identical(dxd_ergm$stats.table.dissolution, dxd_ergm.ego$stats.table.dissolution)
       expect_identical(dxd_ergm$pages, dxd_ergm.ego$pages)
       expect_identical(dxd_ergm$pages_imptd, dxd_ergm.ego$pages_imptd)
-        
+
       param <- param.net(inf.prob = 0.3, act.rate = 0.5)
       init <- init.net(i.num = 10)
       control <- control.net(type = "SI", nsims = 1, nsteps = 5, verbose = FALSE)
-      
+
       set.seed(0)
       sim_ergm <- netsim(netest_ergm, param, init, control)
       set.seed(0)
       sim_ergm.ego <- netsim(netest_ergm.ego, param, init, control)
-      
+
       expect_identical(sim_ergm$stats, sim_ergm.ego$stats)
       expect_identical(sim_ergm$epi, sim_ergm.ego$epi)
     }

--- a/tests/testthat/test-netdx.R
+++ b/tests/testthat/test-netdx.R
@@ -331,11 +331,15 @@ for (trim in c(FALSE, TRUE)) {
     dx11 <- netdx(est, nsims = 5, nsteps = 100, verbose = FALSE)
     expect_length(dx11$stats.table.duration$Target, 11)
     expect_length(dx11$stats.table.dissolution$`Sim Mean`, 11)
-    suppressWarnings({
+    suppressMessages({
       expect_output(print(dx11), "match.neighborhood.7")
       plot(dx11)
-      plot(dx11, type = "duration")
-      plot(dx11, type = "dissolution")
+      capture_output(
+        plot(dx11, type = "duration")
+      )
+      capture_output(
+        plot(dx11, type = "dissolution")
+      )
     })
 
     formation <- ~edges + nodemix("position")

--- a/tests/testthat/test-netest.R
+++ b/tests/testthat/test-netest.R
@@ -321,12 +321,12 @@ test_that("environment handling in non-nested EDA", {
   expect_error(netdx_1 <- netdx(netest_1, nsims = 2, nsteps = 5, dynamic = TRUE, verbose = FALSE),
                "object 'a' not found")
 
-  netest_2 <- netest(nw = nw,
-                     formation = ~edges + nodematch(r, diff = TRUE),
-                     target.stats = c(500, 50, 50, 90, 40, 60),
-                     coef.diss = coef_diss,
-                     nested.edapprox = FALSE,
-                     from.new = "a")
+  supressWarnings(netest_2 <- netest(nw = nw,
+                                     formation = ~edges + nodematch(r, diff = TRUE),
+                                     target.stats = c(500, 50, 50, 90, 40, 60),
+                                     coef.diss = coef_diss,
+                                     nested.edapprox = FALSE,
+                                     from.new = "a"))
 
   expect_error(netdx_2 <- netdx(netest_2, nsims = 2, nsteps = 5, dynamic = TRUE, verbose = FALSE), NA)
 

--- a/tests/testthat/test-netest.R
+++ b/tests/testthat/test-netest.R
@@ -321,12 +321,12 @@ test_that("environment handling in non-nested EDA", {
   expect_error(netdx_1 <- netdx(netest_1, nsims = 2, nsteps = 5, dynamic = TRUE, verbose = FALSE),
                "object 'a' not found")
 
-  supressWarnings(netest_2 <- netest(nw = nw,
-                                     formation = ~edges + nodematch(r, diff = TRUE),
-                                     target.stats = c(500, 50, 50, 90, 40, 60),
-                                     coef.diss = coef_diss,
-                                     nested.edapprox = FALSE,
-                                     from.new = "a"))
+  suppressWarnings(netest_2 <- netest(nw = nw,
+                                      formation = ~edges + nodematch(r, diff = TRUE),
+                                      target.stats = c(500, 50, 50, 90, 40, 60),
+                                      coef.diss = coef_diss,
+                                      nested.edapprox = FALSE,
+                                      from.new = "a"))
 
   expect_error(netdx_2 <- netdx(netest_2, nsims = 2, nsteps = 5, dynamic = TRUE, verbose = FALSE), NA)
 


### PR DESCRIPTION
When I run `testthat::test_package()` on EpiModel, this triggers this Warning:

```r
── Warning (Line 27): environment handling in non-nested EDA ───────────────────
Argument(s) ‘from.new’ were not recognized or used. Did you mistype an argument name?
Backtrace:
  1. EpiModel::netest(...)
 24. rlang (local) `<fn>`(`<rlb_rr__>`)
 25. handlers[[1L]](cnd)
```

which points to these lines in test-netest.R:

```r
  netest_2 <- netest(nw = nw,
                     formation = ~edges + nodematch(r, diff = TRUE),
                     target.stats = c(500, 50, 50, 90, 40, 60),
                     coef.diss = coef_diss,
                     nested.edapprox = FALSE,
                     from.new = "a")
```

It seems like `from.new` is passed through correctly to netest's `...`, so I don't think this is a concern. Yet, is there a way we can stop triggering this warning?