### PR TITLE
remove nonsimp_update.formula

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,4 +66,5 @@ RoxygenNote: 7.2.3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Remotes: github::statnet/ergm@master,
+  github::statnet/ergm.ego@master,
   github::statnet/tergm@master

--- a/R/EpiModel-package.R
+++ b/R/EpiModel-package.R
@@ -144,8 +144,7 @@
 #' @importFrom utils head tail packageVersion
 #' @importFrom ape as.phylo collapse.singles
 #' @importFrom lazyeval lazy_dots lazy_eval
-#' @importFrom statnet.common trim_env nonsimp_update.formula append_rhs.formula
-#'             list_rhs.formula set.control.class check.control.class NVL
+#' @importFrom statnet.common trim_env set.control.class check.control.class NVL
 #' @importFrom methods is
 #' @importFrom tibble as_tibble tibble
 #' @importFrom coda effectiveSize

--- a/R/netest.R
+++ b/R/netest.R
@@ -229,7 +229,7 @@ netest <- function(nw, formation, target.stats, coef.diss, constraints,
     out$newnetwork <- as.network(fit$newnetwork)
     delete.network.attribute(out$newnetwork, "time")
     delete.network.attribute(out$newnetwork, "lasttoggle")
-    out$formula <- fit$formula
+    out$formula <- trim_env(fit$formula, keep = c("formation", "dissolution"))
 
   } else {
 

--- a/R/netest.R
+++ b/R/netest.R
@@ -379,7 +379,6 @@ diss_check <- function(formation, dissolution) {
 #' @param nested.edapprox Logical. If \code{edapprox = TRUE} the dissolution
 #'        model is an initial segment of the formation model (see details in
 #'        \code{\link{netest}}).
-#' @param ... Additional arguments passed to other functions.
 #'
 #' @details
 #' Fitting an ERGM is a computationally intensive process when the model
@@ -422,7 +421,7 @@ diss_check <- function(formation, dissolution) {
 #'}
 #'
 update_dissolution <- function(old.netest, new.coef.diss,
-                               nested.edapprox = TRUE, ...) {
+                               nested.edapprox = TRUE) {
 
   if (!inherits(old.netest, "netest")) {
     stop("old.netest must be an object of class netest", call. = FALSE)

--- a/R/netest.R
+++ b/R/netest.R
@@ -267,7 +267,6 @@ netest <- function(nw, formation, target.stats, coef.diss, constraints,
         ## implement the edapprox by appending the dissolution model to the
         ## formation model and appending the relevant values to the vector of
         ## formation model coefficients
-        dissolution <- coef.diss$dissolution
         formation <- trim_env(~Passthrough(formation) + Passthrough(dissolution),
                               keep = c("formation", "dissolution"))
         coef.form <- c(coef.form, -coef.diss$coef.form.corr)

--- a/R/netest.R
+++ b/R/netest.R
@@ -198,7 +198,8 @@ netest <- function(nw, formation, target.stats, coef.diss, constraints,
                     control = set.control.stergm,
                     verbose = verbose)
     } else {
-      fit <- tergm(nw ~ Form(formation) + Persist(dissolution),
+      fit <- tergm(~Form(formation) + Persist(dissolution),
+                   basis = nw,
                    targets = "formation",
                    target.stats = target.stats,
                    offset.coef = c(coef.form, coef.diss$coef.crude),
@@ -231,11 +232,11 @@ netest <- function(nw, formation, target.stats, coef.diss, constraints,
     out$formula <- fit$formula
 
   } else {
-    formation.nw <- nonsimp_update.formula(formation, nw ~ ., from.new = "nw")
 
     if (is(nw, "egor")) {
       # ergm.ego case
-      fit <- ergm.ego(formation.nw,
+      fit <- ergm.ego(formation,
+                      basis = nw,
                       popsize = 0,
                       constraints = constraints,
                       offset.coef = coef.form,
@@ -246,7 +247,8 @@ netest <- function(nw, formation, target.stats, coef.diss, constraints,
 
     } else {
       # ergm case
-      fit <- ergm(formation.nw,
+      fit <- ergm(formation,
+                  basis = nw,
                   target.stats = target.stats,
                   constraints = constraints,
                   offset.coef = coef.form,

--- a/R/utils.R
+++ b/R/utils.R
@@ -395,24 +395,22 @@ netsim_error_logger <- function(dat, s) {
 #' all but the bare essentials needed for simulating a network model with
 #' \code{\link{netsim}}.
 #'
-#' The function always removes \code{environment(object$constraints)} and
-#' \code{environment(object$coef.diss$dissolution)}.
+#' The function always removes the environments of \code{object$constraints} and
+#' \code{object$coef.diss$dissolution}.
 #'
-#' When \code{edapprox = TRUE} in the \code{netest} call, also
-#' removes \code{environment(object$formula)}.
+#' When both \code{edapprox = TRUE} and \code{nested.edapprox = TRUE} in the
+#' \code{netest} call, also removes the environments of \code{object$formula}
+#' and \code{object$formation}.
 #'
-#' When \code{edapprox = FALSE}, also removes all but \code{formation} and
-#' \code{dissolution} from \code{environment(object$formula)}, as well as
-#' \code{environment(environment(object$formula)$formation)} and
-#' \code{environment(environment(object$formula)$dissolution)}.
+#' When both \code{edapprox = TRUE} and \code{nested.edapprox = FALSE} in the
+#' \code{netest} call, also removes the environments of \code{object$formula},
+#' \code{environment(object$formation)$formation}, and
+#' \code{environment(object$formation)$dissolution}.
 #'
-#' When \code{edapprox = FALSE} or both \code{edapprox = TRUE} and
-#' \code{nested.edapprox = TRUE}, also removes
-#' \code{environment(object$formation)}.
-#'
-#' When both \code{edapprox = TRUE} and \code{nested.edapprox = FALSE}, also
-#' removes \code{environment(environment(object$formation)$formation)} and
-#' \code{environment(environment(object$formation)$dissolution)}.
+#' When \code{edapprox = FALSE} in the \code{netest} call, also removes the
+#' environments of \code{object$formation},
+#' \code{environment(object$formula)$formation} and
+#' \code{environment(object$formula)$dissolution}.
 #'
 #' If \code{as.networkLite = TRUE}, converts \code{object$newnetwork} to a
 #' \code{networkLite} object. If \code{keep.fit = FALSE}, removes \code{fit} (if
@@ -450,6 +448,7 @@ trim_netest <- function(object, as.networkLite = TRUE, keep.fit = FALSE) {
     if (object$nested.edapprox == TRUE) {
       object$formation <- trim_env(object$formation)
     } else {
+      # trim environments for formation and dissolution inside formation
       environment(object$formation)$formation <-
         trim_env(environment(object$formation)$formation)
       environment(object$formation)$dissolution <-
@@ -457,10 +456,7 @@ trim_netest <- function(object, as.networkLite = TRUE, keep.fit = FALSE) {
     }
   } else {
     object$formation <- trim_env(object$formation)
-    # keep formation and dissolution in environment so formula can be evaluated
-    object$formula <- trim_env(object$formula,
-                               keep = c("formation", "dissolution"))
-    # but trim environments for formation and dissolution
+    # trim environments for formation and dissolution inside formula
     environment(object$formula)$formation <-
       trim_env(environment(object$formula)$formation)
     environment(object$formula)$dissolution <-

--- a/man/trim_netest.Rd
+++ b/man/trim_netest.Rd
@@ -34,24 +34,22 @@ object (estimated with \code{\link{netest}}). This utility function removes
 all but the bare essentials needed for simulating a network model with
 \code{\link{netsim}}.
 
-The function always removes \code{environment(object$constraints)} and
-\code{environment(object$coef.diss$dissolution)}.
+The function always removes the environments of \code{object$constraints} and
+\code{object$coef.diss$dissolution}.
 
-When \code{edapprox = TRUE} in the \code{netest} call, also
-removes \code{environment(object$formula)}.
+When both \code{edapprox = TRUE} and \code{nested.edapprox = TRUE} in the
+\code{netest} call, also removes the environments of \code{object$formula}
+and \code{object$formation}.
 
-When \code{edapprox = FALSE}, also removes all but \code{formation} and
-\code{dissolution} from \code{environment(object$formula)}, as well as
-\code{environment(environment(object$formula)$formation)} and
-\code{environment(environment(object$formula)$dissolution)}.
+When both \code{edapprox = TRUE} and \code{nested.edapprox = FALSE} in the
+\code{netest} call, also removes the environments of \code{object$formula},
+\code{environment(object$formation)$formation}, and
+\code{environment(object$formation)$dissolution}.
 
-When \code{edapprox = FALSE} or both \code{edapprox = TRUE} and
-\code{nested.edapprox = TRUE}, also removes
-\code{environment(object$formation)}.
-
-When both \code{edapprox = TRUE} and \code{nested.edapprox = FALSE}, also
-removes \code{environment(environment(object$formation)$formation)} and
-\code{environment(environment(object$formation)$dissolution)}.
+When \code{edapprox = FALSE} in the \code{netest} call, also removes the
+environments of \code{object$formation},
+\code{environment(object$formula)$formation} and
+\code{environment(object$formula)$dissolution}.
 
 If \code{as.networkLite = TRUE}, converts \code{object$newnetwork} to a
 \code{networkLite} object. If \code{keep.fit = FALSE}, removes \code{fit} (if

--- a/man/trim_netest.Rd
+++ b/man/trim_netest.Rd
@@ -34,12 +34,8 @@ object (estimated with \code{\link{netest}}). This utility function removes
 all but the bare essentials needed for simulating a network model with
 \code{\link{netsim}}.
 
-Specifically, the function removes:
-\itemize{
-\item \code{environment(object$constraints)}
-\item \code{environment(object$coef.diss$dissolution)}
-\item \code{environment(object$formation)}
-}
+The function always removes \code{environment(object$constraints)} and
+\code{environment(object$coef.diss$dissolution)}.
 
 When \code{edapprox = TRUE} in the \code{netest} call, also
 removes \code{environment(object$formula)}.
@@ -49,13 +45,23 @@ When \code{edapprox = FALSE}, also removes all but \code{formation} and
 \code{environment(environment(object$formula)$formation)} and
 \code{environment(environment(object$formula)$dissolution)}.
 
+When \code{edapprox = FALSE} or both \code{edapprox = TRUE} and
+\code{nested.edapprox = TRUE}, also removes
+\code{environment(object$formation)}.
+
+When both \code{edapprox = TRUE} and \code{nested.edapprox = FALSE}, also
+removes \code{environment(environment(object$formation)$formation)} and
+\code{environment(environment(object$formation)$dissolution)}.
+
 If \code{as.networkLite = TRUE}, converts \code{object$newnetwork} to a
 \code{networkLite} object. If \code{keep.fit = FALSE}, removes \code{fit} (if
 present) from \code{object}.
 
 For the output to be usable in \code{\link{netsim}} simulation, there should
 not be substitutions in the formulas, other than \code{formation} and
-\code{dissolution} in \code{object$formula} when \code{edapprox = FALSE}.
+\code{dissolution} in \code{object$formula} when \code{edapprox = FALSE} and
+in \code{object$formation} when both \code{edapprox = TRUE} and
+\code{nested.edapprox = FALSE}.
 }
 \examples{
 nw <- network_initialize(n = 100)

--- a/man/update_dissolution.Rd
+++ b/man/update_dissolution.Rd
@@ -4,7 +4,7 @@
 \alias{update_dissolution}
 \title{Adjust Dissolution Component of Network Model Fit}
 \usage{
-update_dissolution(old.netest, new.coef.diss, nested.edapprox = TRUE, ...)
+update_dissolution(old.netest, new.coef.diss, nested.edapprox = TRUE)
 }
 \arguments{
 \item{old.netest}{An object of class \code{netest}, from the
@@ -16,8 +16,6 @@ update_dissolution(old.netest, new.coef.diss, nested.edapprox = TRUE, ...)
 \item{nested.edapprox}{Logical. If \code{edapprox = TRUE} the dissolution
 model is an initial segment of the formation model (see details in
 \code{\link{netest}}).}
-
-\item{...}{Additional arguments passed to other functions.}
 }
 \value{
 An updated network model object of class \code{netest}.

--- a/tests/testthat/test-netest.R
+++ b/tests/testthat/test-netest.R
@@ -363,3 +363,187 @@ test_that("environment handling in non-nested EDA", {
   netest_2 <- update_dissolution(netest_1, coef_diss_2, nested.edapprox = FALSE)
   netdx_2 <- netdx(netest_2, nsims = 2, nsteps = 5, dynamic = TRUE, verbose = FALSE)
 })
+
+test_that("non-nested EDA produces expected statistic names, with or without trimming", {
+  for (trim in c(FALSE, TRUE)) {
+    nw <- network.initialize(10, directed = FALSE)
+    nw %v% "race" <- rep(1:3, length.out = 10)
+    nw %v% "age" <- rep(1:2, length.out = 10)
+
+    coef_diss <- dissolution_coefs(~offset(edges) + offset(nodematch("age", diff = TRUE)),
+                                   c(10, 25, 20))
+    est <- netest(nw,
+                  formation = ~edges + nodematch("race", diff = TRUE),
+                  target.stats = c(10, 3, 2, 1),
+                  coef.diss = coef_diss,
+                  nested.edapprox = FALSE)
+
+    if (trim == TRUE) {
+      est <- trim_netest(est)
+    }
+
+    formation_names <- c("edges", "nodematch.race.1", "nodematch.race.2",
+                         "nodematch.race.3", "offset(edges)", "offset(nodematch.age.1)",
+                         "offset(nodematch.age.2)")
+
+    dxs <- netdx(est, nsims = 100, dynamic = FALSE)
+    expect_equal(rownames(dxs$stats.table.formation), formation_names)
+
+    dxd <- netdx(est, nsims = 2, nsteps = 7, dynamic = TRUE)
+    expect_equal(rownames(dxd$stats.table.formation), formation_names)
+
+    param <- param.net(inf.prob = 0.3, act.rate = 0.5)
+    init <- init.net(i.num = 3)
+    control <- control.net(type = "SI", nsims = 1, nsteps = 5, verbose = FALSE)
+    sim <- netsim(est, param, init, control)
+    expect_equal(colnames(get_nwstats(sim, mode = "list")[[1]]), formation_names)
+  }
+})
+
+test_that("trimming non-nested EDA fails when it should", {
+  nw <- network.initialize(10, directed = FALSE)
+  nw %v% "race" <- rep(1:3, length.out = 10)
+  nw %v% "age" <- rep(1:2, length.out = 10)
+
+  coef_diss <- dissolution_coefs(~offset(edges) + offset(nodematch("age", diff = TRUE)),
+                                 c(10, 25, 20))
+
+  r <- "race"
+
+  est <- netest(nw,
+                formation = ~edges + nodematch(r, diff = TRUE),
+                target.stats = c(10, 3, 2, 1),
+                coef.diss = coef_diss,
+                nested.edapprox = FALSE)
+
+  est <- trim_netest(est)
+
+  expect_error(dxs <- netdx(est, nsims = 100, dynamic = FALSE), "object 'r' not found")
+  expect_error(dxd <- netdx(est, nsims = 2, nsteps = 7, dynamic = TRUE), "object 'r' not found")
+
+  param <- param.net(inf.prob = 0.3, act.rate = 0.5)
+  init <- init.net(i.num = 3)
+  control <- control.net(type = "SI", nsims = 1, nsteps = 5, verbose = FALSE)
+  expect_error(sim <- netsim(est, param, init, control), "object 'r' not found")
+
+  a <- "age"
+  coef_diss <- dissolution_coefs(~offset(edges) + offset(nodematch(a, diff = TRUE)),
+                                 c(10, 25, 20))
+
+  est <- netest(nw,
+                formation = ~edges + nodematch("race", diff = TRUE),
+                target.stats = c(10, 3, 2, 1),
+                coef.diss = coef_diss,
+                nested.edapprox = FALSE)
+
+  est <- trim_netest(est)
+
+  expect_error(dxs <- netdx(est, nsims = 100, dynamic = FALSE), "object 'a' not found")
+  expect_error(dxd <- netdx(est, nsims = 2, nsteps = 7, dynamic = TRUE), "object 'a' not found")
+
+  param <- param.net(inf.prob = 0.3, act.rate = 0.5)
+  init <- init.net(i.num = 3)
+  control <- control.net(type = "SI", nsims = 1, nsteps = 5, verbose = FALSE)
+  expect_error(sim <- netsim(est, param, init, control), "object 'a' not found")
+})
+
+test_that("non-nested EDA with substitutions", {
+  nw <- network_initialize(n = 100)
+  nw %v% "race" <- rep(letters[1:3], length.out = 100)
+  nw %v% "age" <- rep(1:2, length.out = 100)
+
+  make_form <- function() {
+    a <- "race"
+    ff <- ~edges + nodematch(a, diff = TRUE)
+    ff
+  }
+
+  make_diss_1 <- function() {
+    a <- "age"
+    ff <- ~offset(edges) + offset(nodematch(a, diff = TRUE))
+    ff
+  }
+
+  make_diss_2 <- function() {
+    a <- "race"
+    ff <- ~offset(edges) + offset(nodematch(a, diff = TRUE))
+    ff
+  }
+
+  make_diss_3 <- function() {
+    b <- "age"
+    ff <- ~offset(edges) + offset(nodematch(b, diff = TRUE))
+    ff
+  }
+
+  make_diss_4 <- function() {
+    b <- "race"
+    ff <- ~offset(edges) + offset(nodematch(b, diff = TRUE))
+    ff
+  }
+
+  formation_names_r <- c("edges", "nodematch.race.a", "nodematch.race.b",
+                         "nodematch.race.c")
+
+  formation_names_ra <- c("edges", "nodematch.race.a", "nodematch.race.b",
+                          "nodematch.race.c", "offset(edges)", "offset(nodematch.age.1)",
+                          "offset(nodematch.age.2)")
+
+  formation_names_rr <- c("edges", "nodematch.race.a", "nodematch.race.b",
+                          "nodematch.race.c", "offset(edges)", "offset(nodematch.race.a)",
+                          "offset(nodematch.race.b)", "offset(nodematch.race.c)")
+
+  diss_1 <- dissolution_coefs(make_diss_1(), c(10, 5, 7))
+  diss_2 <- dissolution_coefs(make_diss_2(), c(5, 4, 7, 8))
+  diss_3 <- dissolution_coefs(make_diss_3(), c(20, 50, 19))
+  diss_4 <- dissolution_coefs(make_diss_4(), c(3, 2, 9, 4))
+
+  formation <- make_form()
+
+  est_1 <- netest(nw = nw,
+                  formation = formation,
+                  target.stats = c(100, 10, 20, 30),
+                  coef.diss = diss_1,
+                  nested.edapprox = FALSE)
+
+  est_2 <- netest(nw = nw,
+                  formation = formation,
+                  target.stats = c(100, 10, 20, 30),
+                  coef.diss = diss_2)
+
+  run_sims <- function(est, expected_names) {
+    dxs <- netdx(est, nsims = 10, dynamic = FALSE)
+    dxd <- netdx(est, nsims = 2, nsteps = 5, dynamic = TRUE)
+    param <- param.net(inf.prob = 0.3, act.rate = 0.5)
+    init <- init.net(i.num = 3)
+    control <- control.net(type = "SI", nsims = 1, nsteps = 5, verbose = FALSE)
+    sim <- netsim(est, param, init, control)
+
+    expect_equal(rownames(dxs$stats.table.formation), expected_names)
+    expect_equal(rownames(dxd$stats.table.formation), expected_names)
+    expect_equal(colnames(get_nwstats(sim, mode = "list")[[1]]), expected_names)
+  }
+
+  run_sims(est_1, formation_names_ra)
+  run_sims(est_2, formation_names_r)
+
+  est_11 <- update_dissolution(est_1, diss_1, nested.edapprox = FALSE)
+  est_12 <- update_dissolution(est_1, diss_2, nested.edapprox = TRUE)
+  est_13 <- update_dissolution(est_1, diss_3, nested.edapprox = FALSE)
+  est_14 <- update_dissolution(est_1, diss_4, nested.edapprox = FALSE)
+
+  run_sims(est_11, formation_names_ra)
+  run_sims(est_12, formation_names_r)
+  run_sims(est_13, formation_names_ra)
+  run_sims(est_14, formation_names_rr)
+
+  est_21 <- update_dissolution(est_2, diss_1, nested.edapprox = FALSE)
+  est_22 <- update_dissolution(est_2, diss_2, nested.edapprox = TRUE)
+  est_23 <- update_dissolution(est_2, diss_3, nested.edapprox = FALSE)
+  est_24 <- update_dissolution(est_2, diss_4, nested.edapprox = FALSE)
+
+  run_sims(est_21, formation_names_ra)
+  run_sims(est_22, formation_names_r)
+  run_sims(est_23, formation_names_ra)
+  run_sims(est_24, formation_names_rr)
+})


### PR DESCRIPTION
stacked on #825

closes #806

Eliminates remaining uses of `nonsimp_update.formula` (and `append_rhs.formula`), avoiding potential issues that can arise with environments when these functions are used to manipulate formulas.

Depends on `master` versions of `ergm`, `ergm.ego`, and `tergm`.