### PR TITLE
update multinets news version number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+## EpiModel 2.4.0
+
+### NEW FEATURES
+
+- `netsim` now supports multiple networks (with a common node set)
+
+### BUG FIXES
+
+### OTHER
+
+
 ## EpiModel 2.3.2
 
 ### NEW FEATURES
@@ -5,7 +16,6 @@
 - Estimation with the `ergm.ego` package estimation is now supported. This is accomplished by passing an `egor` class object instead of a `network` class object as the `nw` argument to `netest`.
 - Added an `end.horizon` control setting to `control.net`. This allows one to remove a set of modules within network epidemic models at a given time step. This end horizon is needed for cost-effectiveness analyses and related models that require tracking person time in the absence of disease transmision.
 - Added `.traceback.on.error` and `.dump.frames.on.error` controls to print the `traceback` on error even on multicore settings and `dump.frames` for remote debugging.
-- `netsim` now supports multiple networks (with a common node set)
 
 ### BUG FIXES
 


### PR DESCRIPTION
This relocates the multinets news item to version 2.4.0.