### PR TITLE
no message on step 1 for get_cumulative edgelist

### DIFF
--- a/R/el_cuml.R
+++ b/R/el_cuml.R
@@ -63,7 +63,7 @@ get_cumulative_edgelist <- function(dat, network) {
       calculated. (`cumulative.edgelist` control == FALSE)")
   }
 
-  if (length(dat[["el.cuml"]]) < network) {
+  if (is.null(dat[["el.cuml"]][[network]]) && get_current_timestep(dat) > 1) {
   message(
       "\n\nAt timestep = ", get_current_timestep(dat), ":\n",
       "    the cumulative edgelist for network '", network,


### PR DESCRIPTION
fixes #838
also change for `is_null` instead of testing length. This way if only network 3 is updated, we still get the message when trying to access networks 1 and 2 as they are not there.