### PR TITLE
On reinit, use provided params

### DIFF
--- a/R/net.mod.init.R
+++ b/R/net.mod.init.R
@@ -72,7 +72,7 @@ initialize.net <- function(x, param, init, control, s) {
            paste.and(missing_names), call. = FALSE)
     }
 
-    dat <- create_dat_object(param = x$param, control = control)
+    dat <- create_dat_object(param = param, control = control)
 
     dat$num.nw <- x$num.nw
     if (control[["tergmLite"]] == TRUE) {

--- a/R/net.mod.init.R
+++ b/R/net.mod.init.R
@@ -74,9 +74,14 @@ initialize.net <- function(x, param, init, control, s) {
 
     dat <- create_dat_object(param = param, control = control)
 
-    if (is.null(param[["groups"]])) {
-      dat <- set_param(dat, "groups", x$param$groups)
+    missing_params <- setdiff(names(x$param), names(param))
+    for (mp in missing_params) {
+      dat <- set_param(dat, mp, x$param[[mp]])
     }
+
+    # recycle sims in the restart object
+    # e.g. 5 sim out of a size 3 restart object we will give: 1, 2, 3, 1, 2
+    s <- (s - 1) %% length(x$attr) + 1
 
     dat$num.nw <- x$num.nw
     if (control[["tergmLite"]] == TRUE) {

--- a/R/net.mod.init.R
+++ b/R/net.mod.init.R
@@ -74,6 +74,10 @@ initialize.net <- function(x, param, init, control, s) {
 
     dat <- create_dat_object(param = param, control = control)
 
+    if (is.null(param[["groups"]])) {
+      dat <- set_param(dat, "groups", x$param$groups)
+    }
+
     dat$num.nw <- x$num.nw
     if (control[["tergmLite"]] == TRUE) {
       dat$el <- x$el[[s]]

--- a/tests/testthat/test-netrestart.R
+++ b/tests/testthat/test-netrestart.R
@@ -80,7 +80,7 @@ test_that("reinitialization works with open population, nwterms, and epi.by", {
 
   for (tergmLite in c(FALSE, TRUE)) {
     control <- control.net(type = "SI", nsteps = 5,
-                           nsims = 1, resimulate.network = TRUE,
+                           nsims = 2, resimulate.network = TRUE,
                            verbose = FALSE, tergmLite = tergmLite,
                            epi.by = "race",
                            save.other = c("attr", "temp", if (tergmLite) c("el", "net_attr")))


### PR DESCRIPTION
The reinit code in EpiModel now superseeds the `reinit_msm` however, this function behavior is to copy the params from the restart point and not use the ones provided by netsim.

This PR reverts that as it is the  way we modify params for the scenario API (and even without).