### PR TITLE
Fix issue with `other` in `merge.netsim`

### DIFF
--- a/R/merge.R
+++ b/R/merge.R
@@ -251,7 +251,9 @@ merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
         for (i in new.range) {
           z[[other.x[j]]][[i]] <- y[[other.x[j]]][[i - x$control$nsims]]
         }
-        names(z[[other.x[j]]]) <- newnames
+        if (!is.null(z[[other.x[j]]])) {
+          names(z[[other.x[j]]]) <- newnames
+        }
       }
     } else {
       for (j in seq_along(other.x)) {


### PR DESCRIPTION
check that the `other` element is not `NULL` before trying to assign a new name to it

fixes https://github.com/EpiModel/EpiModelHPC/issues/41