### PR TITLE
add a control check for `nsteps`

### DIFF
--- a/R/netsim.R
+++ b/R/netsim.R
@@ -204,6 +204,10 @@ netsim_validate_control <- function(control) {
     control[[".checkpoint.steps"]] <- as.integer(control[[".checkpoint.steps"]])
   }
 
+  if (control$nsteps < 1 || control$nsteps == Inf) {
+    stop("`control$nsteps` must be positive and not infinite.")
+  }
+
   return(control)
 }
 


### PR DESCRIPTION
previoulsy if `Inf` was passed to `control$nsteps`, the error would occur in the first call to `set_epi` due to the wrong value passed to `rep(NA, nsteps)`.

This PR makes the error explicit