### PR TITLE
Consolidate arguments checking in accessors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,9 @@ needed during model runs.
 - Speed up cumulative edge-list calculation by splitting current and historic
 edges.
 - Remove `deleteAttr` function deprecated since 2.4.0
+- all function accepting `posit_ids` as argument must now pass exclusively a
+numeric vector. Logical vectors are not accepted anymore as they were making the
+code heavier and were very error prone.
 
 ## EpiModel 2.4.0
 

--- a/R/net.accessor.R
+++ b/R/net.accessor.R
@@ -11,7 +11,7 @@
 #'        edit (for \code{set_} and \code{append_} functions). Can be of length
 #'        > 1 for \code{get_*_list} functions.
 #' @param posit_ids For \code{set_attr} and \code{get_attr}, a numeric vector of
-#'        posit_ids or a logical vector to subset the desired \code{item}.
+#'        posit_ids to subset the desired \code{item}.
 #' @param value New value to be attributed in the \code{set_} and \code{append_}
 #'        functions.
 #' @param override.null.error If TRUE, \code{get_} will return NULL if the
@@ -69,7 +69,6 @@
 #' get_epi_list(dat, c("i.num", "s.num"))
 #' get_epi(dat, "i.num")
 #' get_epi(dat, "i.num", c(1, 4))
-#' get_epi(dat, "i.num", rbinom(150, 1, 0.2) == 1)
 #'
 #' dat <- add_param(dat, "x")
 #' dat <- set_param(dat, "x", 0.4)
@@ -197,63 +196,6 @@ set_attr <- function(dat, item, value, posit_ids = NULL,
 
   return(dat)
 }
-
-# #' @rdname net-accessor
-# #' @export
-# set_attr <- function(dat, item, value, posit_ids = NULL,
-#                      override.length.check = FALSE) {
-#   attr_list <- raw_get_attr_list(dat)
-#   if (!item %in% names(attr_list)) {
-#     dat <- add_attr(dat, item)
-#   }
-#
-#   attr <- attr_list[[item]]
-#
-#   if (is.null(posit_ids)) {
-#     if (!override.length.check && length(value) != length(attr)) {
-#       stop(
-#         "When trying to edit the ", `item`, " nodal attribute: ",
-#         "The size of the `value` vector is not equal to the number of nodes in",
-#         " the network. \n",
-#         "Expected: ", length(attr), "\n",
-#         "Given: ", length(value)
-#       )
-#     }
-#
-#     attr <- value
-#   } else {
-#     if (is.logical(posit_ids) && length(posit_ids) != length(attr)) {
-#       stop("(logical) `posit_ids` has to have a length equal to the number ",
-#         "of nodes in the network")
-#     } else if (is.numeric(posit_ids)) {
-#       if (length(posit_ids) == 0) {
-#         return(dat)
-#       } else if (any(posit_ids > length(attr))) {
-#         stop("Some (numeric) `posit_ids` are larger than the number of nodes ",
-#              " in the network")
-#       }
-#     } else {
-#       stop("`posit_ids` must be logical, numeric, or NULL")
-#     }
-#
-#     if (!override.length.check &&
-#       length(value) != 1 &&
-#       length(value) != length(posit_ids)) {
-#       stop(
-#         "When trying to edit the `", item, "` nodal attribute: ",
-#         "The size of the `value` vector is not equal to the number of nodes ",
-#         "selected by the `posit_ids` vector nor of length 1. \n",
-#         "Expected: ", length(posit_ids), " or 1 \n",
-#         "Given: ", length(value)
-#       )
-#     }
-#
-#     attr[posit_ids] <- value
-#     dat <- raw_set_attr(dat, item, attr)
-#   }
-#
-#   return(dat)
-# }
 
 #' @rdname net-accessor
 #' @export

--- a/R/reachable.R
+++ b/R/reachable.R
@@ -113,10 +113,10 @@ get_forward_reachable <- function(el_cuml, from_step, to_step, nodes = NULL,
   #     (QoL to calcuate the `change_times`)
   # nolint start
   el_cuml <- el_cuml |>
-    dplyr::mutate(stop = ifelse(is.na(stop), Inf, stop)) |> # current edges never ends
-    dplyr::filter(start <= to_step, stop >= from_step) |> # remove edges before and after analysis period
-    dplyr::mutate(start = ifelse(start < from_step, from_step, start)) |> # set older edges to start at beginning of analysis
-    dplyr::select(start, stop, head, tail)
+    dplyr::mutate(stop = ifelse(is.na(.data$stop), Inf, .data$stop)) |> # current edges never ends
+    dplyr::filter(.data$start <= to_step, .data$stop >= from_step) |> # remove edges before and after analysis period
+    dplyr::mutate(start = ifelse(.data$start < from_step, from_step, .data$start)) |> # set older edges to start at beginning of analysis
+    dplyr::select("start", "stop", "head", "tail")
   # nolint end
 
   # Make the node indexes continuous
@@ -323,24 +323,25 @@ dedup_cumulative_edgelist <- function(el) {
     dplyr::ungroup()
 
   e_unique <- el_n |>
-    dplyr::filter(n == 1) |>
-    dplyr::select(-n)
+    dplyr::filter(.data$n == 1) |>
+    dplyr::select(-"n")
 
   e_dup <- el_n |>
-    dplyr::filter(n > 1) |>
-    dplyr::select(-n) |>
-    dplyr::arrange(head, tail, start, stop)
+    dplyr::filter(.data$n > 1) |>
+    dplyr::select(-"n") |>
+    dplyr::arrange(.data$head, .data$tail, .data$start, .data$stop)
 
   e_dedup <- e_dup |>
-    dplyr::group_by(head, tail) |>
+    dplyr::group_by(.data$head, .data$tail) |>
     dplyr::mutate(
-      lstart = dplyr::lag(start),
-      lstop = dplyr::lag(stop),
-      overlap = !is.na(lstop) & !is.na(lstart) & start <= lstop,
-      stop = ifelse(overlap, max(stop, lstop, na.rm = TRUE), stop),
-      start = ifelse(overlap, min(start, lstart, na.rm = TRUE), start)
+      lstart = dplyr::lag(.data$start),
+      lstop = dplyr::lag(.data$stop),
+      overlap = !is.na(.data$lstop) & !is.na(.data$lstart) &
+                .data$start <= .data$lstop,
+      stop = ifelse(.data$overlap, max(.data$stop, .data$lstop, na.rm = TRUE), .data$stop),
+      start = ifelse(.data$overlap, min(.data$start, .data$lstart, na.rm = TRUE), .data$start)
     ) |>
-    dplyr::select(-c(lstart, lstop, overlap)) |>
+    dplyr::select(-c(.data$lstart, .data$lstop, .data$overlap)) |>
     dplyr::ungroup() |>
     unique()
 

--- a/man/net-accessor.Rd
+++ b/man/net-accessor.Rd
@@ -87,7 +87,7 @@ edit (for \code{set_} and \code{append_} functions). Can be of length
 > 1 for \code{get_*_list} functions.}
 
 \item{posit_ids}{For \code{set_attr} and \code{get_attr}, a numeric vector of
-posit_ids or a logical vector to subset the desired \code{item}.}
+posit_ids to subset the desired \code{item}.}
 
 \item{override.null.error}{If TRUE, \code{get_} will return NULL if the
 \code{item} does not exist instead of throwing an error.
@@ -166,7 +166,6 @@ get_epi_list(dat)
 get_epi_list(dat, c("i.num", "s.num"))
 get_epi(dat, "i.num")
 get_epi(dat, "i.num", c(1, 4))
-get_epi(dat, "i.num", rbinom(150, 1, 0.2) == 1)
 
 dat <- add_param(dat, "x")
 dat <- set_param(dat, "x", 0.4)

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -25,7 +25,6 @@ test_that("`dat` getters and setter", {
 
   expect_equal(get_attr(dat, "age"), new_ages)
   expect_equal(get_attr(dat, "age", c(1, 5)), new_ages[c(1, 5)])
-  expect_equal(get_attr(dat, "age", new_ages > 0.5), new_ages[new_ages > 0.5])
 
   expect_error(get_attr(dat, "age_absent"))
   expect_null(get_attr(dat, "age_absent", override.null.error = TRUE))
@@ -36,14 +35,12 @@ test_that("`dat` getters and setter", {
 
   expect_silent(dat <- set_attr(dat, "age", 2, posit_ids = 1:4))
   expect_equal(get_attr(dat, "age", 1:4), rep(2, 4))
-  posit_ids <- c(rep(TRUE, 4), rep(FALSE, n_nodes - 4))
-  expect_silent(dat <- set_attr(dat, "age", 6, posit_ids = posit_ids))
-  expect_equal(get_attr(dat, "age", 1:4), rep(6, 4))
 
   expect_error(dat <- set_attr(dat, "age", c(1, 2), posit_ids = 1:4))
   expect_error(dat <- set_attr(dat, "age", 1, posit_ids = c(1, 1000)))
-  expect_error(dat <- set_attr(dat, "age", 1, posit_ids = c("a", "b")))
-  expect_error(dat <- set_attr(dat, "age", c(1, 2), posit_ids = c(TRUE, FALSE)))
+
+  expect_error(dat <- set_attr(dat, "age", 1, posit_ids = TRUE))
+  expect_error(dat <- set_attr(dat, "age", 1, posit_ids = "a"))
 
 
   expect_error(get_attr_list(dat, "sex"))
@@ -71,7 +68,6 @@ test_that("`dat` getters and setter", {
   expect_equal(get_epi(dat, "s")[110], 10)
 
   expect_equal(get_epi(dat, "i", c(1, 100)), dat$epi$i[c(1, 100)])
-  expect_equal(get_epi(dat, "i", dat$epi$i > 0.5), dat$epi$i[dat$epi$i > 0.5])
 
   expect_error(get_epi(dat, "age_absent"))
   expect_null(get_epi(dat, "age_absent", override.null.error = TRUE))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -45,6 +45,7 @@ test_that("color_tea", {
 
 test_that("delete_attr", {
   dat <- create_dat_object()
+  dat <- append_core_attr(dat, 1, 5)
   dat <- append_attr(dat, "a", 1:5, 5)
   dat <- append_attr(dat, "b", 6:10, 5)
 


### PR DESCRIPTION
- single `assert_valid_posit_ids` function shared among accessors
- single `assert_valid_time_steps` function shared among accessors
- removal of logical subsetting in accessors
- code reformatting for consistency with the rest of the codebase
- update the tests to reflect the changes

fixes #822 