### PR TITLE
MCMC.maxchanges = Inf

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### OTHER
 
 - Fix bug where the `ellipsis` (`...`) was not passed correctly to the `base::plot` in the `plot.netsim` function.
+- Set `MCMC.maxchanges = Inf` as default for TERGM MCMC. Lift the check on the maximum number of MCMC changes per step for bigger or dense networks.
 
 ## EpiModel 2.5
 

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -882,7 +882,7 @@ control.net <- function(type,
                         raw.output = FALSE,
                         tergmLite.track.duration = FALSE,
                         set.control.ergm = control.simulate.formula(MCMC.burnin = 2e5),
-                        set.control.tergm = control.simulate.formula.tergm(),
+                        set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
                         save.diss.stats = TRUE,
                         dat.updates = NULL,
                         ...) {

--- a/R/netdx.R
+++ b/R/netdx.R
@@ -125,7 +125,7 @@
 netdx <- function(x, nsims = 1, dynamic = TRUE, nsteps,
                   nwstats.formula = "formation",
                   set.control.ergm = control.simulate.formula(),
-                  set.control.tergm = control.simulate.formula.tergm(),
+                  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
                   sequential = TRUE, keep.tedgelist = FALSE,
                   keep.tnetwork = FALSE, verbose = TRUE, ncores = 1,
                   skip.dissolution = FALSE) {

--- a/R/netest.R
+++ b/R/netest.R
@@ -146,7 +146,7 @@
 netest <- function(nw, formation, target.stats, coef.diss, constraints,
                    coef.form = NULL, edapprox = TRUE,
                    set.control.ergm = control.ergm(),
-                   set.control.tergm = control.tergm(),
+                   set.control.tergm = control.tergm(MCMC.maxchanges = Inf),
                    set.control.ergm.ego = NULL,
                    verbose = FALSE, nested.edapprox = TRUE, ...) {
 

--- a/man/control.net.Rd
+++ b/man/control.net.Rd
@@ -40,7 +40,7 @@ control.net(
   raw.output = FALSE,
   tergmLite.track.duration = FALSE,
   set.control.ergm = control.simulate.formula(MCMC.burnin = 2e+05),
-  set.control.tergm = control.simulate.formula.tergm(),
+  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
   save.diss.stats = TRUE,
   dat.updates = NULL,
   ...

--- a/man/netdx.Rd
+++ b/man/netdx.Rd
@@ -11,7 +11,7 @@ netdx(
   nsteps,
   nwstats.formula = "formation",
   set.control.ergm = control.simulate.formula(),
-  set.control.tergm = control.simulate.formula.tergm(),
+  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
   sequential = TRUE,
   keep.tedgelist = FALSE,
   keep.tnetwork = FALSE,

--- a/man/netest.Rd
+++ b/man/netest.Rd
@@ -13,7 +13,7 @@ netest(
   coef.form = NULL,
   edapprox = TRUE,
   set.control.ergm = control.ergm(),
-  set.control.tergm = control.tergm(),
+  set.control.tergm = control.tergm(MCMC.maxchanges = Inf),
   set.control.ergm.ego = NULL,
   verbose = FALSE,
   nested.edapprox = TRUE,


### PR DESCRIPTION
Fixes #904

set `MCMC.maxchanges = Inf` in all `control.*tergm()` calls. 