### PR TITLE
Fix MCMC.maxchanges = Inf integer coercion warning in tergm

### DIFF
--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -882,7 +882,7 @@ control.net <- function(type,
                         raw.output = FALSE,
                         tergmLite.track.duration = FALSE,
                         set.control.ergm = control.simulate.formula(MCMC.burnin = 2e5),
-                        set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
+                        set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = .Machine$integer.max),
                         save.diss.stats = TRUE,
                         dat.updates = NULL,
                         ...) {

--- a/R/netdx.R
+++ b/R/netdx.R
@@ -125,7 +125,7 @@
 netdx <- function(x, nsims = 1, dynamic = TRUE, nsteps = NULL,
                   nwstats.formula = "formation",
                   set.control.ergm = control.simulate.formula(),
-                  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
+                  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = .Machine$integer.max),
                   sequential = TRUE, keep.tedgelist = FALSE,
                   keep.tnetwork = FALSE, verbose = TRUE, ncores = 1,
                   skip.dissolution = FALSE) {

--- a/R/netest.R
+++ b/R/netest.R
@@ -146,7 +146,7 @@
 netest <- function(nw, formation, target.stats, coef.diss, constraints = NULL,
                    coef.form = NULL, edapprox = TRUE,
                    set.control.ergm = control.ergm(),
-                   set.control.tergm = control.tergm(MCMC.maxchanges = Inf),
+                   set.control.tergm = control.tergm(MCMC.maxchanges = .Machine$integer.max),
                    set.control.ergm.ego = NULL,
                    verbose = FALSE, nested.edapprox = TRUE, ...) {
 

--- a/man/control.net.Rd
+++ b/man/control.net.Rd
@@ -40,7 +40,8 @@ control.net(
   raw.output = FALSE,
   tergmLite.track.duration = FALSE,
   set.control.ergm = control.simulate.formula(MCMC.burnin = 2e+05),
-  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
+  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges =
+    .Machine$integer.max),
   save.diss.stats = TRUE,
   dat.updates = NULL,
   ...

--- a/man/netdx.Rd
+++ b/man/netdx.Rd
@@ -11,7 +11,8 @@ netdx(
   nsteps = NULL,
   nwstats.formula = "formation",
   set.control.ergm = control.simulate.formula(),
-  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges = Inf),
+  set.control.tergm = control.simulate.formula.tergm(MCMC.maxchanges =
+    .Machine$integer.max),
   sequential = TRUE,
   keep.tedgelist = FALSE,
   keep.tnetwork = FALSE,

--- a/man/netest.Rd
+++ b/man/netest.Rd
@@ -13,7 +13,7 @@ netest(
   coef.form = NULL,
   edapprox = TRUE,
   set.control.ergm = control.ergm(),
-  set.control.tergm = control.tergm(MCMC.maxchanges = Inf),
+  set.control.tergm = control.tergm(MCMC.maxchanges = .Machine$integer.max),
   set.control.ergm.ego = NULL,
   verbose = FALSE,
   nested.edapprox = TRUE,


### PR DESCRIPTION
Replace MCMC.maxchanges = Inf with .Machine$integer.max in netdx(), control.net(), and netest() defaults.

When Inf is passed as MCMC.maxchanges, it flows to tergm::tergm_MCMC_slave() which calls as.integer(maxchanges) before the .Call to MCMCDyn_wrapper. as.integer(Inf) produces NA with a warning: "NAs introduced by coercion to integer range".

Note that tergm wraps the analogous MCMC.maxedges parameter with deInf(maxedges, "maxint") before as.integer(), which correctly converts Inf to .Machine$integer.max. The same deInf() wrapper is missing for MCMC.maxchanges in tergm_MCMC_slave(). This is arguably a bug in tergm -- see the relevant code:

  tergm::tergm_MCMC_slave:
    maxedges <- NVL(control$MCMC.maxedges, Inf)
    maxchanges <- control$MCMC.maxchanges
    z <- .Call("MCMCDyn_wrapper", ...,
              as.integer(deInf(maxedges, "maxint")),  # <- wrapped
              as.integer(maxchanges),                  # <- NOT wrapped
              ...)

This warning surfaced after ergm 4.12.0 (2026-02-17) triggered a recompilation of the tergm binary, likely changing how the C code uses the maxchanges argument.

Using .Machine$integer.max (2,147,483,647) is functionally equivalent to Inf for this purpose -- it effectively removes the limit on MCMC changes per step -- while avoiding the integer coercion warning.

* Related to https://github.com/EpiModel/EpiModel/pull/920
* Issue for tergm filed at https://github.com/statnet/tergm/issues/136