### PR TITLE
Clean up duplicated quantile/mean logic in plot_netsim_epi() and plot.icm()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,10 +19,14 @@
 -   Fix `mutate_epi()` to replicate scalar constants across all simulations/runs and use existing column names instead of hardcoding `"run1"`. Closes #984.
 -   Fix mismatched `mean.lwd` defaults in `plot.netsim()` where dead-code `is.null` branches used inconsistent values (1.5 vs 2.5). Removed the dead branches since the function signature already provides a default of 2. Closes #983.
 -   Fix unreachable two-group validation in `crosscheck.dcm()` where checks for `rec.rate.g2` and `r.num.g2` were nested after `stop()` calls, preventing them from ever executing. Closes #982.
+-   Fix `ylim` in `plot.netsim(type = "epi")` so the auto-range expands to fit quantile polygons when `mean.line = FALSE`. The previous `qnts == TRUE` guard only matched `qnts = 1` / `qnts = TRUE`, leaving polygons potentially clipped at the default `qnts = 0.5`. Closes #1009.
+-   Fix `plot.icm()` to skip drawing quantile polygons when `qnts = FALSE`, matching the documented behavior. Previously this case produced a degenerate zero-width band rather than suppressing the polygon.
 
 ### OTHER
 
 -   Replace direct `dat$run$nw[[network]]` accesses with `get_network()`/`set_network()` accessors across internal modules (`edgelists.R`, `net.fn.utils.R`, `net.mod.init.R`, `net.mod.nwupdate.R`, `saveout.R`, `update.R`) (#977).
+-   Consolidate duplicated quantile and mean-line logic in `plot.netsim(type = "epi")` so the `disp.qnts` setup, `mean.lwd` / `mean.lty` expansion, and `draw_qnts()` / `draw_means()` call signatures are not repeated across the ylim-calc and drawing phases. Closes #997.
+-   Apply the same consolidation to `plot.icm()` to keep the two sibling plotting paths structurally symmetric. Closes #1010.
 
 ## EpiModel 2.6.0
 

--- a/R/plot.icm.R
+++ b/R/plot.icm.R
@@ -187,25 +187,33 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
   mean.min <- 1E10
   mean.max <- -1E10
 
-  ## Quantiles - ylim min max ##
-  if (nsims > 1) {
-    if (qnts > 1 || qnts < 0) {
-      stop("qnts must be between 0 and 1")
+  ## Quantile and mean line setup (used in both ylim calc and drawing) ##
+  if (qnts == FALSE || nsims == 1) {
+    disp.qnts <- FALSE
+  } else {
+    disp.qnts <- TRUE
+  }
+  if (disp.qnts && (qnts > 1 || qnts < 0)) {
+    stop("qnts must be between 0 and 1")
+  }
+
+  if (mean.line == TRUE) {
+    if (length(mean.lwd) < lcomp) {
+      mean.lwd <- rep(mean.lwd, lcomp)
     }
+    if (length(mean.lty) < lcomp) {
+      mean.lty <- rep(mean.lty, lcomp)
+    }
+  }
+
+  ## Quantiles - ylim min max ##
+  if (disp.qnts) {
     qnt.min <- draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 0, "min", offset)
     qnt.max <- draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 0, "max", offset)
   }
 
   ## Mean lines - ylim max ##
   if (mean.line == TRUE) {
-
-    if (length(mean.lwd) < lcomp) {
-      mean.lwd <- rep(mean.lwd, lcomp)
-    }
-
-    if (length(mean.lty) < lcomp) {
-      mean.lty <- rep(mean.lty, lcomp)
-    }
     mean.min <- draw_means(x, y, mean.smooth, mean.lwd,
                            mean.pal, mean.lty, "epi", 0, "min", offset)
     mean.max <- draw_means(x, y, mean.smooth, mean.lwd,
@@ -239,11 +247,8 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
 
 
   ## Quantiles - Plotting ##
-  if (nsims > 1) {
-    if (qnts > 1 || qnts < 0) {
-      stop("qnts must be between 0 and 1")
-    }
-    draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, offset = offset)
+  if (disp.qnts) {
+    draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 1, "max", offset)
   }
 
   ## Simulation lines ##
@@ -259,16 +264,8 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
 
   ## Mean lines - plotting ##
   if (mean.line == TRUE) {
-
-    if (length(mean.lwd) < lcomp) {
-      mean.lwd <- rep(mean.lwd, lcomp)
-    }
-
-    if (length(mean.lty) < lcomp) {
-      mean.lty <- rep(mean.lty, lcomp)
-    }
     draw_means(x, y, mean.smooth, mean.lwd, mean.pal, mean.lty,
-               offset = offset)
+               "epi", 1, "max", offset)
   }
 
   ## Grid

--- a/R/plot.netsim.R
+++ b/R/plot.netsim.R
@@ -464,7 +464,7 @@ plot_netsim_epi <- function(x, y = NULL, sims = NULL, legend = NULL,
   if (is.null(ylim) && (popfrac || sim.lines)) {
     ylim <- c(min.prev, max.prev)
   } else if (is.null(ylim) && !popfrac && !sim.lines &&
-               (mean.line || qnts == TRUE)) {
+               (mean.line || disp.qnts)) {
     ylim <- c(
       min(qnt.min * 0.9, mean.min * 0.9),
       max(qnt.max * 1.1, mean.max * 1.1)

--- a/R/plot.netsim.R
+++ b/R/plot.netsim.R
@@ -419,23 +419,16 @@ plot_netsim_epi <- function(x, y = NULL, sims = NULL, legend = NULL,
   mean.min <- 1E10
   mean.max <- -1E10
 
-  ## Quantiles - ylim max ##
+  ## Quantile and mean line setup (used in both ylim calc and drawing) ##
   if (qnts == FALSE || nsims == 1) {
     disp.qnts <- FALSE
   } else {
     disp.qnts <- TRUE
   }
-
-  if (disp.qnts) {
-    if (qnts > 1 || qnts < 0) {
-      stop("qnts must be between 0 and 1")
-    }
-    qnt.max <- draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 0, "max", offset)
-    qnt.min <- draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 0, "min", offset)
+  if (disp.qnts && (qnts > 1 || qnts < 0)) {
+    stop("qnts must be between 0 and 1")
   }
 
-
-  ## Mean lines - ylim max ##
   if (mean.line) {
     if (length(mean.lwd) < lcomp) {
       mean.lwd <- rep(mean.lwd, lcomp)
@@ -443,6 +436,16 @@ plot_netsim_epi <- function(x, y = NULL, sims = NULL, legend = NULL,
     if (length(mean.lty) < lcomp) {
       mean.lty <- rep(mean.lty, lcomp)
     }
+  }
+
+  ## Quantiles - ylim max ##
+  if (disp.qnts) {
+    qnt.max <- draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 0, "max", offset)
+    qnt.min <- draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 0, "min", offset)
+  }
+
+  ## Mean lines - ylim max ##
+  if (mean.line) {
     mean.max <- draw_means(
       x, y,
       mean.smooth, mean.lwd, mean.pal, mean.lty,
@@ -485,23 +488,8 @@ plot_netsim_epi <- function(x, y = NULL, sims = NULL, legend = NULL,
   }
 
   ## Quantiles ##
-  ## NOTE: Why is this repeated from above?
-  if (qnts == FALSE) {
-    disp.qnts <- FALSE
-  } else {
-    disp.qnts <- TRUE
-  }
-  if (nsims == 1) {
-    disp.qnts <- FALSE
-  }
-
-  if (disp.qnts == TRUE) {
-    if (qnts > 1 || qnts < 0) {
-      stop("qnts must be between 0 and 1")
-    }
-    y.l <- length(y)
-    qnts.pal <- qnts.pal[1:y.l]
-    draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, offset = offset)
+  if (disp.qnts) {
+    draw_qnts(x, y, qnts, qnts.pal, qnts.smooth, "epi", 1, "max", offset)
   }
 
 
@@ -518,16 +506,8 @@ plot_netsim_epi <- function(x, y = NULL, sims = NULL, legend = NULL,
 
   ## Mean lines ##
   if (mean.line) {
-    if (length(mean.lwd) < lcomp) {
-      mean.lwd <- rep(mean.lwd, lcomp)
-    }
-    if (length(mean.lty) < lcomp) {
-      mean.lty <- rep(mean.lty, lcomp)
-    }
-    y.n <- length(y)
-    mean.pal <- mean.pal[seq_len(y.n)]
     draw_means(x, y, mean.smooth, mean.lwd, mean.pal, mean.lty,
-               offset = offset)
+               "epi", 1, "max", offset)
   }
 
   ## Grid


### PR DESCRIPTION
Closes #997, closes #1009, closes #1010.

## Summary

Cleans up duplicated quantile/mean-line logic in both `plot_netsim_epi()` (`R/plot.netsim.R`) and `plot.icm()` (`R/plot.icm.R`), and fixes a latent `ylim` bug in the netsim path. The two functions share `draw_qnts()` / `draw_means()` helpers in `R/plot.R`, so `CLAUDE.md` requires changes to be coordinated across them — this PR does both.

### Deduplication in `plot_netsim_epi()` (#997)

1. **Single `disp.qnts` setup.** The quantile enable/validate logic previously appeared in both the ylim-calc phase and the drawing phase (the latter with a `## NOTE: Why is this repeated from above?` comment). It now runs once, before either phase.
2. **Single `mean.lwd` / `mean.lty` expansion.** The `rep()` expansion that padded these vectors to length `lcomp` previously ran twice; the second call was a no-op. Now runs once under a single `if (mean.line)` guard.
3. **Consistent `draw_qnts()` / `draw_means()` signatures.** Both phases now pass all positional args explicitly (`"epi"`, `0|1`, `"max"`, `offset`) instead of relying on the drawing-phase defaults matching the ylim-phase explicit args.

Also removes trailing `qnts.pal[1:y.l]` / `mean.pal[seq_len(y.n)]` subsetting in the drawing phase — the helpers only index palettes at `[j]` for `j in seq_len(lcomp)` and the legend call below takes `length(legend)` entries from `col`, so the subsetting was cosmetic.

### ylim bug fix in `plot_netsim_epi()` (#1009)

The `ylim` auto-calc branch used `qnts == TRUE` in its guard, which only matched `qnts = 1` / `qnts = TRUE`. For the default `qnts = 0.5` with `mean.line = FALSE`, `ylim` was never expanded to fit the quantile polygon even though it was drawn. Now uses `disp.qnts` (available from the deduplication consolidation above), so `ylim` tracks whatever is actually plotted. The sentinel `qnt.*` / `mean.*` initializers (`±1E10`) ensure the `min`/`max` formula still works correctly in the previously-exercised `mean.line=TRUE` / `nsims=1` case.

### Matching cleanup in `plot.icm()` (#1010)

Applies the same three-part consolidation to `plot.icm()` so it stays structurally symmetric with `plot_netsim_epi()`.

**Secondary effect**: `plot.icm()` previously guarded only on `nsims > 1`, so passing `qnts = FALSE` with `nsims > 1` would still call `draw_qnts()` with `qnts = FALSE`, producing a degenerate `c(0.5, 0.5)` quantile band (effectively invisible, but not cleanly skipped). The consolidated `disp.qnts` guard now skips the polygon call entirely for `qnts = FALSE`, aligning the implementation with the function's own documentation: *"To toggle off the polygons where they are plotted by default, specify `qnts=FALSE`"*. No user-visible change for the default `qnts = 0.5` path; users relying on `qnts = FALSE` now get the documented behavior.

## Behavior preservation

For `plot_netsim_epi()`, verified `disp.qnts` construction across `(qnts, nsims)` combinations — `FALSE/5`, `0/5`, `0.5/5`, `0.5/1`, `TRUE/5`, `1/5` — all match the original control flow. The `qnts == FALSE` form (rather than `isFALSE(qnts)`) is kept deliberately to preserve R's coercion behavior at `qnts = 0`.

For `plot.icm()`, default-path behavior (`qnts = 0.5`, `nsims > 1`, `mean.line = TRUE`) is unchanged; only the `qnts = FALSE` edge case is affected (now skipped as documented).