### PR TITLE
Fix inconsistencies between plot.netsim stats and plot.netdx

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 -   Replace direct `dat$run$nw[[network]]` accesses with `get_network()`/`set_network()` accessors across internal modules (`edgelists.R`, `net.fn.utils.R`, `net.mod.init.R`, `net.mod.nwupdate.R`, `saveout.R`, `update.R`) (#977).
 -   Consolidate duplicated quantile and mean-line logic in `plot.netsim(type = "epi")` so the `disp.qnts` setup, `mean.lwd` / `mean.lty` expansion, and `draw_qnts()` / `draw_means()` call signatures are not repeated across the ylim-calc and drawing phases. Closes #997.
 -   Apply the same consolidation to `plot.icm()` to keep the two sibling plotting paths structurally symmetric. Closes #1010.
+-   Extract duplicated stats validation logic from `plot_netsim_stats()` and `plot.netdx()` into a shared `validate_stats_selection()` helper; add `xlim`, `xlab`, `ylim`, `ylab` parameters to `plot.netdx()` for parity with `plot.netsim(type = "formation")`. Closes #998.
 
 ## EpiModel 2.6.0
 

--- a/R/plot.netdx.R
+++ b/R/plot.netdx.R
@@ -125,7 +125,9 @@ plot.netdx <- function(x, type = "formation", method = "l", sims = NULL,
                        mean.lty = 1, qnts = 0.5, qnts.col = NULL,
                        qnts.alpha = 0.5, qnts.smooth = TRUE, targ.line = TRUE,
                        targ.col = NULL, targ.lwd = 2, targ.lty = 2,
-                       plots.joined = NULL, legend = NULL, grid = FALSE, ...) {
+                       plots.joined = NULL, legend = NULL, grid = FALSE,
+                       xlim = NULL, xlab = NULL, ylim = NULL, ylab = NULL,
+                       ...) {
 
   type <- match.arg(type, c("formation", "duration", "dissolution"))
   sims <- if (is.null(sims)) seq_len(x$nsims) else sims
@@ -162,24 +164,12 @@ plot.netdx <- function(x, type = "formation", method = "l", sims = NULL,
     }
   }
 
-  ## Find available stats
-  sts <- which(!is.na(stats_table[, "Sim Mean"]))
-  nmstats <- rownames(stats_table)[sts]
-
-  ## Pull and check stat argument
-  stats <- if (is.null(stats)) nmstats else stats
-  if (!all(stats %in% nmstats)) {
-    stop("One or more requested stats not contained in netdx object") 
-  }
-  outsts <- which(nmstats %in% stats)
-  nmstats <- nmstats[outsts]
-
-  ## Subset data
-  data <- data[, outsts, , drop = FALSE]
+  sel <- validate_stats_selection(stats_table, data, stats, "netdx object")
+  data <- sel$data
+  nmstats <- sel$nmstats
+  targets <- sel$targets
   # sims only used to subset data in dynamic case
   if (x$dynamic) data <- data[, , sims, drop = FALSE]
-  ## Pull target stats
-  targets <- stats_table$Target[sts][outsts]
 
   plot_stats_table(
     data = data,
@@ -206,6 +196,8 @@ plot.netdx <- function(x, type = "formation", method = "l", sims = NULL,
     grid = grid,
     targets = targets,
     dynamic = x$dynamic,
+    xlim = xlim, xlab = xlab,
+    ylim = ylim, ylab = ylab,
     ...
   )
 }

--- a/R/plot.netsim.R
+++ b/R/plot.netsim.R
@@ -583,24 +583,10 @@ plot_netsim_stats <- function(x, type, sims, stats, network, duration.imputed,
   stats_table <- make_stats_table(data, ts)
   data <- array(unlist(data), dim = c(dim(data[[1]]), nsims))
 
-  ## Find available stats
-  sts <- which(!is.na(stats_table[, "Sim Mean"]))
-  nmstats <- rownames(stats_table)[sts]
-
-  ## Pull and check stat argument
-  stats <- if (is.null(stats)) nmstats else stats
-  if (!all(stats %in% nmstats)) {
-    stop("One or more requested stats not contained in netsim object")
-  }
-  outsts <- which(nmstats %in% stats)
-  nmstats <- nmstats[outsts]
-
-  ## Subset data
-  data <- data[, outsts, , drop = FALSE]
-  ## we've already subset the data to `sims`
-
-  ## Pull target stats
-  targets <- stats_table$Target[sts][outsts]
+  sel <- validate_stats_selection(stats_table, data, stats, "netsim object")
+  data <- sel$data
+  nmstats <- sel$nmstats
+  targets <- sel$targets
 
   plot_stats_table(
     data = data,

--- a/R/plot.stat_table.R
+++ b/R/plot.stat_table.R
@@ -1,3 +1,21 @@
+validate_stats_selection <- function(stats_table, data, stats,
+                                     obj_type = "object") {
+  sts <- which(!is.na(stats_table[, "Sim Mean"]))
+  nmstats <- rownames(stats_table)[sts]
+
+  stats <- if (is.null(stats)) nmstats else stats
+  if (!all(stats %in% nmstats)) {
+    stop("One or more requested stats not contained in ", obj_type)
+  }
+  outsts <- which(nmstats %in% stats)
+  nmstats <- nmstats[outsts]
+
+  data <- data[, outsts, , drop = FALSE]
+  targets <- stats_table$Target[sts][outsts]
+
+  list(data = data, nmstats = nmstats, targets = targets)
+}
+
 plot_stats_table <- function(data, nmstats, method,
                              sim.lines,
                              sim.col = NULL, sim.lwd = NULL, mean.line,

--- a/man/plot.netdx.Rd
+++ b/man/plot.netdx.Rd
@@ -30,6 +30,10 @@
   plots.joined = NULL,
   legend = NULL,
   grid = FALSE,
+  xlim = NULL,
+  xlab = NULL,
+  ylim = NULL,
+  ylab = NULL,
   ...
 )
 }
@@ -103,6 +107,18 @@ versus one plot per statistic if \code{FALSE}.}
 
 \item{grid}{If \code{TRUE}, a grid is added to the background of plot
 (see \code{\link[=grid]{grid()}} for details), with default of nx by ny.}
+
+\item{xlim}{the x limits (x1, x2) of the plot.  Note that \code{x1 > x2}
+    is allowed and leads to a \sQuote{reversed axis}.
+
+    The default value, \code{NULL}, indicates that the range of the
+    \link{finite} values to be plotted should be used.}
+
+\item{xlab}{a label for the x axis, defaults to a description of \code{x}.}
+
+\item{ylim}{the y limits of the plot.}
+
+\item{ylab}{a label for the y axis, defaults to a description of \code{y}.}
 
 \item{...}{Additional arguments to pass.}
 }


### PR DESCRIPTION
## Summary

Closes #998.

- Extract duplicated stats validation logic (find available stats, validate user's `stats` argument, subset data, pull targets) from `plot_netsim_stats()` and `plot.netdx()` into a shared `validate_stats_selection()` helper in `R/plot.stat_table.R`
- Add `xlim`, `xlab`, `ylim`, `ylab` parameters to `plot.netdx()` and pass them through to `plot_stats_table()`, matching the interface already available via `plot.netsim(type = "formation")`
- `dynamic` parameter handling left as-is — both sides are correct (`plot.netdx` reads from the object, `plot_netsim_stats` hardcodes `TRUE` since netsim is always dynamic)

## Test plan

- [x] `R CMD check` passes
- [x] `plot(dx, type = "formation", xlim = ..., ylim = ..., xlab = ..., ylab = ...)` works on a `netdx` object
- [x] `plot(sim, type = "formation")` on a `netsim` object still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)