### PR TITLE
Clarify module.order/resimulate.network interaction, warn on tergmLite override

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 -   Consolidate duplicated quantile and mean-line logic in `plot.netsim(type = "epi")` so the `disp.qnts` setup, `mean.lwd` / `mean.lty` expansion, and `draw_qnts()` / `draw_means()` call signatures are not repeated across the ylim-calc and drawing phases. Closes #997.
 -   Apply the same consolidation to `plot.icm()` to keep the two sibling plotting paths structurally symmetric. Closes #1010.
 -   Extract duplicated stats validation logic from `plot_netsim_stats()` and `plot.netdx()` into a shared `validate_stats_selection()` helper; add `xlim`, `xlab`, `ylim`, `ylab` parameters to `plot.netdx()` for parity with `plot.netsim(type = "formation")`. Closes #998.
+-   Clarify in `control.net()` docs that `module.order` is independent of `resimulate.network`, and that `tergmLite = TRUE` forces `resimulate.network = TRUE`. Change the `tergmLite` override from `message()` to `warning()` so it is visible in batch/HPC logs. Add tests for module ordering with both `resimulate.network` settings. Closes #466.
 
 ## EpiModel 2.6.0
 

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -657,9 +657,13 @@ init.net <- function(i.num, r.num, i.num.g2, r.num.g2,
 #'        simulation and must be less than the value in `nsteps`.
 #' @param resimulate.network If `TRUE`, resimulate the network at each time step. This is required
 #'        when the epidemic or demographic processes impact the network structure (e.g., vital
-#'        dynamics).
+#'        dynamics). This parameter controls whether `resim_nets.FUN` performs actual network
+#'        resimulation; it does not affect the order in which modules are executed (see
+#'        `module.order`). Setting `tergmLite = TRUE` forces `resimulate.network = TRUE` with a
+#'        warning.
 #' @param tergmLite Logical indicating usage of either `tergm` (`tergmLite = FALSE`), or `tergmLite`
-#'        (`tergmLite = TRUE`). Default of `FALSE`.
+#'        (`tergmLite = TRUE`). Default of `FALSE`. When `TRUE`, `resimulate.network` is
+#'        automatically set to `TRUE` (with a warning if the user explicitly set it to `FALSE`).
 #' @param cumulative.edgelist If `TRUE`, calculates a cumulative edgelist within the network
 #'        simulation module. This is used when tergmLite is used and the entire networkDynamic
 #'        object is not used.
@@ -695,6 +699,10 @@ init.net <- function(i.num, r.num, i.num.g2, r.num.g2,
 #'        as follows: first any new modules supplied through `...` in the order in which they are
 #'        listed, then the built-in modules in the order in which they are listed as arguments
 #'        above. `initialize.FUN` will always be run first and `verbose.FUN` will always be run last.
+#'        Module ordering is independent of `resimulate.network`: the specified order is always
+#'        respected regardless of whether network resimulation is enabled. In the default ordering,
+#'        `resim_nets.FUN` runs before `infection.FUN`, so the network is resimulated before
+#'        transmission is evaluated at each time step.
 #' @param save.nwstats If `TRUE`, save network statistics in a data frame. The statistics to be
 #'        saved are specified in the `nwstats.formula` argument.
 #' @param nwstats.formula A right-hand sided ERGM formula that includes network statistics of
@@ -973,7 +981,8 @@ control.net <- function(type,
   }
 
   if (p[["tergmLite"]] == TRUE && p[["resimulate.network"]] == FALSE) {
-    message("Because tergmLite = TRUE, resetting resimulate.network = TRUE")
+    warning("Because tergmLite = TRUE, resetting resimulate.network = TRUE",
+            call. = FALSE)
     p[["resimulate.network"]] <- TRUE
   }
 

--- a/man/control.net.Rd
+++ b/man/control.net.Rd
@@ -69,10 +69,14 @@ other \code{future} backends.}
 
 \item{resimulate.network}{If \code{TRUE}, resimulate the network at each time step. This is required
 when the epidemic or demographic processes impact the network structure (e.g., vital
-dynamics).}
+dynamics). This parameter controls whether \code{resim_nets.FUN} performs actual network
+resimulation; it does not affect the order in which modules are executed (see
+\code{module.order}). Setting \code{tergmLite = TRUE} forces \code{resimulate.network = TRUE} with a
+warning.}
 
 \item{tergmLite}{Logical indicating usage of either \code{tergm} (\code{tergmLite = FALSE}), or \code{tergmLite}
-(\code{tergmLite = TRUE}). Default of \code{FALSE}.}
+(\code{tergmLite = TRUE}). Default of \code{FALSE}. When \code{TRUE}, \code{resimulate.network} is
+automatically set to \code{TRUE} (with a warning if the user explicitly set it to \code{FALSE}).}
 
 \item{cumulative.edgelist}{If \code{TRUE}, calculates a cumulative edgelist within the network
 simulation module. This is used when tergmLite is used and the entire networkDynamic
@@ -122,7 +126,11 @@ function of \code{\link{prevalence.net}}.}
 they should be evaluated within each time step. If \code{NULL}, the modules will be evaluated
 as follows: first any new modules supplied through \code{...} in the order in which they are
 listed, then the built-in modules in the order in which they are listed as arguments
-above. \code{initialize.FUN} will always be run first and \code{verbose.FUN} will always be run last.}
+above. \code{initialize.FUN} will always be run first and \code{verbose.FUN} will always be run last.
+Module ordering is independent of \code{resimulate.network}: the specified order is always
+respected regardless of whether network resimulation is enabled. In the default ordering,
+\code{resim_nets.FUN} runs before \code{infection.FUN}, so the network is resimulated before
+transmission is evaluated at each time step.}
 
 \item{save.nwstats}{If \code{TRUE}, save network statistics in a data frame. The statistics to be
 saved are specified in the \code{nwstats.formula} argument.}

--- a/tests/testthat/test-newmodules.R
+++ b/tests/testthat/test-newmodules.R
@@ -161,6 +161,57 @@ test_that("New network models vignette example", {
 
 })
 
+test_that("module.order is independent of resimulate.network", {
+  skip_on_cran()
+
+  nw <- network_initialize(n = 50)
+  est <- netest(nw, formation = ~edges, target.stats = 15,
+                coef.diss = dissolution_coefs(~offset(edges), 60),
+                verbose = FALSE)
+  param <- param.net(inf.prob = 0.3)
+  init <- init.net(i.num = 5)
+
+  custom_order <- c("resim_nets.FUN", "infection.FUN",
+                     "nwupdate.FUN", "prevalence.FUN")
+
+  # module.order preserved with resimulate.network = TRUE
+  ctrl1 <- control.net(type = "SI", nsims = 1, nsteps = 5,
+                        module.order = custom_order,
+                        resimulate.network = TRUE, verbose = FALSE)
+  expect_equal(ctrl1$module.order, custom_order)
+  mod1 <- netsim(est, param, init, ctrl1)
+  expect_s3_class(mod1, "netsim")
+
+  # module.order preserved with resimulate.network = FALSE
+  ctrl2 <- control.net(type = "SI", nsims = 1, nsteps = 5,
+                        module.order = custom_order,
+                        resimulate.network = FALSE, verbose = FALSE)
+  expect_equal(ctrl2$module.order, custom_order)
+  mod2 <- netsim(est, param, init, ctrl2)
+  expect_s3_class(mod2, "netsim")
+})
+
+test_that("tergmLite = TRUE warns when overriding resimulate.network", {
+  expect_warning(
+    control.net(type = "SI", nsteps = 10,
+                tergmLite = TRUE, resimulate.network = FALSE),
+    "resimulate.network"
+  )
+
+  # confirm the override took effect
+  ctrl <- suppressWarnings(
+    control.net(type = "SI", nsteps = 10,
+                tergmLite = TRUE, resimulate.network = FALSE)
+  )
+  expect_true(ctrl$resimulate.network)
+
+  # no warning when resimulate.network = TRUE (no conflict)
+  expect_no_warning(
+    control.net(type = "SI", nsteps = 10,
+                tergmLite = TRUE, resimulate.network = TRUE)
+  )
+})
+
 context("Network Model with Param Updater")
 
 test_that("netsim with param updater", {


### PR DESCRIPTION
## Summary

Closes #466.

The original issue reported that `resimulate.network = TRUE` overrides `module.order`. Investigation of the current codebase shows this is not the case — `module.order` is always respected regardless of `resimulate.network`. The `resimulate.network` flag only controls whether `resim_nets.FUN` performs actual network resimulation, not the order in which modules execute.

This PR addresses all three actionable items from the issue:

1. **Documentation** — Updated roxygen docs for `resimulate.network`, `tergmLite`, and `module.order` in `control.net()` to clarify their interactions and the default module execution order
2. **`message()` → `warning()`** — The `tergmLite = TRUE` override of `resimulate.network` now uses `warning()` instead of `message()`, so the override is visible in `.Rout` logs and captured by `tryCatch(warnings = ...)`
3. **Tests** — Added tests verifying that `module.order` is preserved with both `resimulate.network = TRUE` and `FALSE`, and that the `tergmLite` override produces a warning

## Test plan

- [x] `R CMD check` passes
- [x] `testthat::test_file("tests/testthat/test-newmodules.R")` — all 60 tests pass
- [x] `tergmLite = TRUE` with `resimulate.network = FALSE` now produces a warning instead of a message

🤖 Generated with [Claude Code](https://claude.com/claude-code)