### PR TITLE
Fix 1012 components

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@ inst/JSS/
 ^pkgdown$
 CLAUDE.md
 ^\.claude$
+^\.positai$

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ inst/doc
 docs
 *.Rcheck/
 *.tar.gz
+.positai

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
     -   `births.FUN` / `deaths.FUN` in `control.net()` -- use `arrivals.FUN` / `departures.FUN` (deprecated since 1.7.0).
     -   `depend` in `control.net()` -- use `resimulate.network` (deprecated since 2.0).
 -   Removed `b.rate` / `b.rate.g2` deprecation guards from `param.dcm()`, `param.icm()`, and `param.net()`. These parameters were renamed to `a.rate` / `a.rate.g2` in v1.7.0; passing them now produces a standard R unused-argument error. Closes #989.
+-   Changed the default of `legend` in `plot.icm()` from `TRUE` to `NULL`. The legend is now auto-shown only when `y` is auto-populated (the no-`y` default); when the caller supplies `y` explicitly, no legend is drawn unless `legend = TRUE` is passed. This matches the more principled `plot.netsim(type = "epi")` policy and avoids a single-entry legend for `plot(mod, y = "i.num")`-style calls. Closes #1012.
 
 ### NEW FEATURES
 
@@ -21,6 +22,8 @@
 -   Fix unreachable two-group validation in `crosscheck.dcm()` where checks for `rec.rate.g2` and `r.num.g2` were nested after `stop()` calls, preventing them from ever executing. Closes #982.
 -   Fix `ylim` in `plot.netsim(type = "epi")` so the auto-range expands to fit quantile polygons when `mean.line = FALSE`. The previous `qnts == TRUE` guard only matched `qnts = 1` / `qnts = TRUE`, leaving polygons potentially clipped at the default `qnts = 0.5`. Closes #1009.
 -   Fix `plot.icm()` to skip drawing quantile polygons when `qnts = FALSE`, matching the documented behavior. Previously this case produced a degenerate zero-width band rather than suppressing the polygon.
+-   Fix `ylim` in `plot.icm()` so the auto-range expands to fit quantile polygons when `mean.line = FALSE`. The previous guard only triggered when `mean.line = TRUE`, leaving polygons potentially clipped against compartment extrema. This is the `plot.icm()` analog of the `plot.netsim()` fix in #1009. Closes #1012.
+-   Fix silent color recycling in `plot.icm()` when more than three compartments are plotted. The internal palette `bpal` was hard-coded to three entries (`c(4, 2, 3)`), so the fourth and subsequent compartments could render as `NA` (invisible) under `adjustcolor()`. Extended to 99 entries to match `plot.netsim(type = "epi")`. Closes #1012.
 
 ### OTHER
 
@@ -29,8 +32,7 @@
 -   Apply the same consolidation to `plot.icm()` to keep the two sibling plotting paths structurally symmetric. Closes #1010.
 -   Extract duplicated stats validation logic from `plot_netsim_stats()` and `plot.netdx()` into a shared `validate_stats_selection()` helper; add `xlim`, `xlab`, `ylim`, `ylab` parameters to `plot.netdx()` for parity with `plot.netsim(type = "formation")`. Closes #998.
 -   Clarify in `control.net()` docs that `module.order` is independent of `resimulate.network`, and that `tergmLite = TRUE` forces `resimulate.network = TRUE`. Change the `tergmLite` override from `message()` to `warning()` so it is visible in batch/HPC logs. Add tests for module ordering with both `resimulate.network` settings. Closes #466.
-
-## EpiModel 2.6.0
+-   Align remaining stylistic differences between `plot.icm()` and `plot_netsim_epi()`: switch `== TRUE` / `== FALSE` boolean guards to the bare form, reorganize the `ylim` auto-calc so `popfrac || sim.lines` is a first-class branch, simplify the `x$param$groups` derivation, and drop the dead `lcomp == 1` special case in the compartment-max block. No behavior change. Tracks the structural-symmetry goal noted in `CLAUDE.md`. Closes #1012; the remaining shared-helper refactor was filed as #1018.
 
 ### BREAKING CHANGES
 

--- a/R/plot.icm.R
+++ b/R/plot.icm.R
@@ -72,7 +72,7 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
                      sim.alpha = NULL, mean.line = TRUE, mean.smooth = TRUE,
                      mean.col = NULL, mean.lwd = 2, mean.lty = 1, qnts = 0.5,
                      qnts.col = NULL, qnts.alpha = 0.5, qnts.smooth = TRUE,
-                     legend = TRUE, leg.cex = 0.8, grid = FALSE, add = FALSE,
+                     legend = NULL, leg.cex = 0.8, grid = FALSE, add = FALSE,
                      xlim = NULL, ylim = NULL, main = "", xlab = "Time",
                      ylab = NULL,
                      ...) {
@@ -89,16 +89,15 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
     stop("Set sim to between 1 and ", nsims)
   }
   if (is.null(x$param$groups) || !is.numeric(x$param$groups)) {
-    groups <- 1
     x$param$groups <- 1
-  } else {
-    groups <- x$param$groups
   }
+  groups <- x$param$groups
 
 
   ## Compartments ##
   nocomp <- is.null(y)
-  if (nocomp == TRUE) {
+  if (nocomp) {
+    legend <- if (is.null(legend)) TRUE else legend
     if (groups == 1) {
       y <- grep(".num$", names(x$epi), value = TRUE)
     }
@@ -108,11 +107,8 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
                grep(".num.g2$", names(x$epi), value = TRUE))
       }
     }
-  }
-  if (nocomp == FALSE) {
-    if (any(y %in% names(x$epi) == FALSE)) {
-      stop("Specified y is not available in object")
-    }
+  } else if (!all(y %in% names(x$epi))) {
+    stop("Specified y is not available in object")
   }
   lcomp <- length(y)
 
@@ -120,7 +116,7 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
   ## Color palettes ##
 
   # Main color palette
-  bpal <- c(4, 2, 3)
+  bpal <- c(4, 2, 3, 5:100)
 
   # Mean line
   if (is.null(mean.col)) {
@@ -162,14 +158,9 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
   x <- denom(x, y, popfrac)
 
   # Compartment max
-  if (popfrac == FALSE) {
-    if (lcomp == 1) {
-      min.prev <- min(x$epi[[y]], na.rm = TRUE)
-      max.prev <- max(x$epi[[y]], na.rm = TRUE)
-    } else {
-      min.prev <- min(sapply(y, function(comps) min(x$epi[[comps]], na.rm = TRUE)))
-      max.prev <- max(sapply(y, function(comps) max(x$epi[[comps]], na.rm = TRUE)))
-    }
+  if (!popfrac) {
+    min.prev <- min(sapply(y, function(comps) min(x$epi[[comps]], na.rm = TRUE)))
+    max.prev <- max(sapply(y, function(comps) max(x$epi[[comps]], na.rm = TRUE)))
   } else {
     min.prev <- 0
     max.prev <- 1
@@ -197,7 +188,7 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
     stop("qnts must be between 0 and 1")
   }
 
-  if (mean.line == TRUE) {
+  if (mean.line) {
     if (length(mean.lwd) < lcomp) {
       mean.lwd <- rep(mean.lwd, lcomp)
     }
@@ -213,7 +204,7 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
   }
 
   ## Mean lines - ylim max ##
-  if (mean.line == TRUE) {
+  if (mean.line) {
     mean.min <- draw_means(x, y, mean.smooth, mean.lwd,
                            mean.pal, mean.lty, "epi", 0, "min", offset)
     mean.max <- draw_means(x, y, mean.smooth, mean.lwd,
@@ -221,25 +212,20 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
   }
 
   # Dynamic scaling based on sim.lines and mean lines and quantile bands
-  if (is.null(ylim)) {
-    if (sim.lines == FALSE && mean.line == TRUE) {
-      ylim <- c(min(qnt.min * 0.9, mean.min * 0.9),
-                max(qnt.max * 1.1, mean.max * 1.1))
-    } else {
-      ylim <- c(min.prev, max.prev)
-    }
+  if (is.null(ylim) && (popfrac || sim.lines)) {
+    ylim <- c(min.prev, max.prev)
+  } else if (is.null(ylim) && !popfrac && !sim.lines &&
+               (mean.line || disp.qnts)) {
+    ylim <- c(min(qnt.min * 0.9, mean.min * 0.9),
+              max(qnt.max * 1.1, mean.max * 1.1))
   }
 
   if (is.null(ylab)) {
-    if (popfrac == FALSE) {
-      ylab <- "Number"
-    } else {
-      ylab <- "Prevalence"
-    }
+    ylab <- if (popfrac) "Prevalence" else "Number"
   }
 
   ## Main plot window ##
-  if (add == FALSE) {
+  if (!add) {
     plot(1, 1, type = "n", bty = "n",
          xlim = xlim, ylim = ylim,
          xlab = xlab, ylab = ylab, main = main, ...)
@@ -252,7 +238,7 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
   }
 
   ## Simulation lines ##
-  if (sim.lines == TRUE) {
+  if (sim.lines) {
     for (j in seq_len(lcomp)) {
       for (i in sims) {
         lines(seq_len(nrow(x$epi[[y[j]]])) + offset,
@@ -263,19 +249,19 @@ plot.icm <- function(x, y = NULL, popfrac = FALSE, sim.lines = FALSE,
 
 
   ## Mean lines - plotting ##
-  if (mean.line == TRUE) {
+  if (mean.line) {
     draw_means(x, y, mean.smooth, mean.lwd, mean.pal, mean.lty,
                "epi", 1, "max", offset)
   }
 
   ## Grid
-  if (grid == TRUE) {
+  if (grid) {
     grid()
   }
 
   ## Legends ##
-  if (legend) {
-    if (groups == 2 && nocomp == TRUE) {
+  if (!is.null(legend) && legend) {
+    if (groups == 2 && nocomp) {
       leg.lty <- mean.lty
     } else {
       leg.lty <- 1

--- a/man/plot.icm.Rd
+++ b/man/plot.icm.Rd
@@ -22,7 +22,7 @@
   qnts.col = NULL,
   qnts.alpha = 0.5,
   qnts.smooth = TRUE,
-  legend = TRUE,
+  legend = NULL,
   leg.cex = 0.8,
   grid = FALSE,
   add = FALSE,


### PR DESCRIPTION
Closes #1012 (items 1–7). The remaining structural-helper refactor (item 8) was filed separately as #1018 under the Longer-Term Issues milestone.

## Summary

Aligns `plot.icm()` with `plot_netsim_epi()` so the two sibling code paths produce identically-formatted output for the same user inputs, and so future maintenance changes apply cleanly to both. All seven items are in `R/plot.icm.R`:

1. **Bare boolean guards** — `nocomp == TRUE`, `mean.line == TRUE`, `popfrac == FALSE`, `sim.lines == TRUE`, `grid == TRUE`, `add == FALSE`, etc. all switched to the bare form to match `plot_netsim_epi` and avoid coercion surprises on non-logical values. Left `qnts == FALSE` as-is in both functions, since it distinguishes the logical-FALSE sentinel from a numeric range.
2. **`ylim` guard now includes `disp.qnts`** — when `mean.line = FALSE` but a quantile polygon is still drawn, `ylim` now scales to the quantile extrema instead of clipping to compartment extrema. Same class of bug #1009 fixed on the netsim side.
3. **`ylim` branch organization** — `popfrac || sim.lines` is now a first-class branch (matches `plot_netsim_epi`) rather than the fallthrough `else`.
4. **`legend` default** — changed from `TRUE` to `NULL`. When `y` is auto-populated, legend defaults to `TRUE` (unchanged behavior). When the user supplies `y`, no legend is drawn by default. **Minor user-visible change**: previously `plot(mod, y = "i.num")` always showed a single-entry legend; now it doesn't unless the caller passes `legend = TRUE`. This matches the more principled `plot_netsim_epi` policy.
5. **`bpal` length** — extended from `c(4, 2, 3)` to `c(4, 2, 3, 5:100)` so plots with more than three compartments get distinct colors instead of NA / recycled values.
6. **Compartment-max special case removed** — `lcomp == 1` no longer needs its own branch; the `sapply` form handles it identically.
7. **`groups` derivation** — set `x$param$groups <- 1` once, then read `groups <- x$param$groups`. Equivalent in effect, structurally identical to `plot_netsim_epi`.

`man/plot.icm.Rd` regenerated by `roxygen2::roxygenise()` — only the `legend = TRUE` → `legend = NULL` line in the usage block.

The unrelated `.Rbuildignore` / `.gitignore` additions for `.positai` are local tooling housekeeping.

## Test plan

- [x] `R CMD check --as-cran` passes; the two NOTEs (invalid `EpiModelHIV-p` URL, old Date field, future timestamps) are pre-existing
- [x] All `tests/testthat/test-icm-long.R` plot calls render without error after the changes (covers SI/SIR/SIS, 1-group/2-group, with/without demography)
- [x] Manual visual smoke test of each item using a temporary `inst/smoke-1012.R` (not committed): `mean.line = FALSE` + qnts now scales `ylim` to the polygon; 5-compartment plot gets 5 distinct colors; legend defaults flip as expected; single-compartment plots still pick `bpal[1]` (blue) correctly
- [x] CI green