### PR TITLE
fix random params get

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 
 ### BUG FIXES
 -   Fix `saveout.net` to preserve `NULL` values when saving simulation outputs across multiple runs. Previously, assigning `NULL` via `out[[name]][[s]] <- value` silently dropped the list entry, causing misaligned simulation indices. Now uses `list()` wrapping to ensure `NULL` values are stored as explicit list elements. Closes #800.
+-   Fix `get_sims()`, `merge.netsim()`, and `get_param_set()` to preserve and report per-simulation `random.params` draw metadata correctly. Subsetting a `netsim` object now subsets `param$random.params.values`; merging compatible `netsim` objects now appends those values instead of retaining only the first object; and one-simulation outputs with vector-valued random parameters are now reported correctly by `get_param_set()`.
 -   Fix `plot.epi.data.frame` to correctly display truncated the time axis.
 -   Fix `paste0(..., sep = ", ")` misuse in `as.data.frame.icm()` epi repair warnings and errors. `paste0()` has no `sep` parameter, causing malformed output with trailing commas. Changed to `paste(..., collapse = ", ")`. Closes #985.
 -   Fix `mutate_epi()` to replicate scalar constants across all simulations/runs and use existing column names instead of hardcoding `"run1"`. Closes #984.

--- a/R/get.R
+++ b/R/get.R
@@ -520,6 +520,7 @@ get_sims <- function(x, sims = NULL, var = NULL) {
   newnames <- paste0("sim", seq_len(out$control$nsims))
 
   delsim <- setdiff(1:nsims, sims)
+  keepsim <- setdiff(seq_len(nsims), delsim)
   if (length(delsim) > 0) {
     for (i in seq_along(out$epi)) {
       out$epi[[i]] <- out$epi[[i]][, -delsim, drop = FALSE]
@@ -554,9 +555,113 @@ get_sims <- function(x, sims = NULL, var = NULL) {
     }
   }
 
+  out$param$random.params.values <- subset_random_params_values(
+    out$param$random.params.values, keepsim, nsims
+  )
+
   if (!is.null(var)) {
     match.vars <- which(names(x$epi) %in% var)
     out$epi <- out$epi[match.vars]
+  }
+
+  return(out)
+}
+
+random_param_draws <- function(value, nsims) {
+  if (is.list(value)) {
+    return(value)
+  }
+
+  if (nsims > 1 && length(value) == nsims) {
+    return(as.list(value))
+  }
+
+  return(list(value))
+}
+
+random_param_from_draws <- function(draws) {
+  if (length(draws) == 0) {
+    return(draws)
+  }
+
+  draw_lengths <- vapply(draws, length, integer(1))
+  draw_is_list <- vapply(draws, is.list, logical(1))
+  if (all(draw_lengths == 1) && !any(draw_is_list)) {
+    return(unname(unlist(draws, recursive = FALSE, use.names = FALSE)))
+  }
+
+  return(draws)
+}
+
+normalize_random_params_values <- function(values, nsims) {
+  if (is.null(values)) {
+    return(NULL)
+  }
+
+  lapply(values, function(value) {
+    random_param_from_draws(random_param_draws(value, nsims))
+  })
+}
+
+subset_random_params_values <- function(values, sims, nsims) {
+  if (is.null(values)) {
+    return(NULL)
+  }
+
+  lapply(values, function(value) {
+    draws <- random_param_draws(value, nsims)
+    random_param_from_draws(draws[sims])
+  })
+}
+
+param_without_random_values <- function(param) {
+  random_value_names <- names(param[["random.params.values"]])
+  param[c(random_value_names, "random.params.values")] <- NULL
+  return(param)
+}
+
+random_param_na_like <- function(value) {
+  if (length(value) == 0) {
+    return(NA)
+  }
+
+  out <- value
+  out[] <- NA
+  return(out)
+}
+
+random_param_missing_draws <- function(nsims, template) {
+  rep(list(random_param_na_like(template)), nsims)
+}
+
+merge_random_params_values <- function(x_values, y_values, x_nsims, y_nsims) {
+  if (is.null(x_values) && is.null(y_values)) {
+    return(NULL)
+  }
+
+  random_names <- union(names(x_values), names(y_values))
+  out <- vector("list", length(random_names))
+  names(out) <- random_names
+
+  for (name in random_names) {
+    x_has_name <- name %in% names(x_values)
+    y_has_name <- name %in% names(y_values)
+
+    if (x_has_name) {
+      x_draws <- random_param_draws(x_values[[name]], x_nsims)
+    }
+    if (y_has_name) {
+      y_draws <- random_param_draws(y_values[[name]], y_nsims)
+    }
+
+    if (!x_has_name) {
+      x_draws <- random_param_missing_draws(x_nsims, y_draws[[1]])
+    }
+    if (!y_has_name) {
+      y_draws <- random_param_missing_draws(y_nsims, x_draws[[1]])
+    }
+
+    out[[name]] <- random_param_from_draws(c(x_draws, y_draws))
   }
 
   return(out)
@@ -655,7 +760,10 @@ get_param_set <- function(sims) {
     stop("`sims` must be of class netsim")
   }
 
-  p.random <- sims[["param"]][["random.params.values"]]
+  p.random <- normalize_random_params_values(
+    sims[["param"]][["random.params.values"]],
+    sims[["control"]][["nsims"]]
+  )
   fixed.names <- setdiff(
     names(sims[["param"]]),
     c(names(p.random), "random.params", "random.params.values")

--- a/R/merge.R
+++ b/R/merge.R
@@ -184,7 +184,8 @@ merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
   }
 
   ## Check params
-  check1 <- identical(x$param, y$param)
+  check1 <- identical(param_without_random_values(x$param),
+                      param_without_random_values(y$param))
   check2 <- identical(x$control[-which(names(x$control) %in%
                                          c("nsims", "monitors",
                                            "nwstats.formula"))],
@@ -207,6 +208,10 @@ merge.netsim <- function(x, y, keep.transmat = TRUE, keep.network = TRUE,
   z <- x
   z$control$nsims <- x$control$nsims + y$control$nsims
   newnames <- paste0("sim", seq_len(z$control$nsims))
+  z$param$random.params.values <- merge_random_params_values(
+    x$param$random.params.values, y$param$random.params.values,
+    x$control$nsims, y$control$nsims
+  )
 
   # Merge epi data
   for (i in seq_along(x$epi)) {

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -168,6 +168,73 @@ test_that("get_sims error flags", {
   expect_true(setequal(names(d.set), set.colnames))
   expect_error(get_param_set(control), "`sims` must be of class netsim")
   expect_equal(dim(get_param_set(mod)), c(3, length(set.colnames)))
+
+  mod.sub <- get_sims(mod, sims = 2)
+  d.sub <- get_param_set(mod.sub)
+  expect_equal(nrow(d.sub), 1)
+  expect_equal(d.sub$act.rate, d.set$act.rate[2])
+  expect_equal(d.sub$dummy.param, d.set$dummy.param[2])
+  expect_equal(d.sub$dummy.strat.param_1, d.set$dummy.strat.param_1[2])
+  expect_equal(d.sub$dummy.strat.param_2, d.set$dummy.strat.param_2[2])
+})
+
+test_that("get_param_set handles vector random parameters with one simulation", {
+  mod <- structure(
+    list(
+      param = list(
+        inf.prob = 0.3,
+        dummy.strat.param = c(0.1, 0.2),
+        random.params = list(dummy.strat.param = function() NULL),
+        random.params.values = list(dummy.strat.param = c(0.1, 0.2))
+      ),
+      control = list(nsims = 1)
+    ),
+    class = "netsim"
+  )
+
+  d.set <- get_param_set(mod)
+  expect_equal(nrow(d.set), 1)
+  expect_equal(d.set$dummy.strat.param_1, 0.1)
+  expect_equal(d.set$dummy.strat.param_2, 0.2)
+})
+
+test_that("get_sims subsets random parameter values", {
+  mod <- structure(
+    list(
+      param = list(
+        inf.prob = 0.3,
+        act.rate = 0.1,
+        dummy.strat.param = c(1, 2),
+        random.params = list(
+          act.rate = function() NULL,
+          dummy.strat.param = function() NULL
+        ),
+        random.params.values = list(
+          act.rate = c(0.1, 0.2, 0.3),
+          dummy.strat.param = list(c(1, 2), c(3, 4), c(5, 6))
+        )
+      ),
+      control = list(nsims = 3, save.other = character(0)),
+      epi = list(
+        i.num = data.frame(matrix(1:3, nrow = 1))
+      ),
+      stats = list(nwstats = NULL, transmat = NULL),
+      run = NULL,
+      network = NULL,
+      diss.stats = NULL
+    ),
+    class = "netsim"
+  )
+
+  mod.sub <- get_sims(mod, sims = 2)
+  d.sub <- get_param_set(mod.sub)
+
+  expect_equal(mod.sub$control$nsims, 1)
+  expect_equal(mod.sub$param$random.params.values$act.rate, 0.2)
+  expect_equal(mod.sub$param$random.params.values$dummy.strat.param, list(c(3, 4)))
+  expect_equal(d.sub$act.rate, 0.2)
+  expect_equal(d.sub$dummy.strat.param_1, 3)
+  expect_equal(d.sub$dummy.strat.param_2, 4)
 })
 
 dxs <- netdx(est, dynamic = FALSE, nsims = 5,

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -149,6 +149,62 @@ test_that("merge.netsim works as expected for transmat", {
   expect_true(is.null(mod4$stats$transmat))
 })
 
+test_that("merge.netsim preserves random parameter values", {
+  random.params <- list(
+    act.rate = function() NULL,
+    dummy.strat.param = function() NULL
+  )
+
+  make_mod <- function(act.rate, dummy.strat.param) {
+    nsims <- length(act.rate)
+    simnames <- paste0("sim", seq_len(nsims))
+    structure(
+      list(
+        param = list(
+          inf.prob = 0.3,
+          act.rate = act.rate[1],
+          dummy.strat.param = dummy.strat.param[[1]],
+          random.params = random.params,
+          random.params.values = list(
+            act.rate = act.rate,
+            dummy.strat.param = dummy.strat.param
+          )
+        ),
+        control = list(
+          nsims = nsims,
+          save.other = character(0),
+          monitors = NULL,
+          nwstats.formula = NULL
+        ),
+        epi = list(
+          i.num = data.frame(
+            matrix(seq_len(nsims), nrow = 1, dimnames = list(NULL, simnames))
+          )
+        ),
+        stats = list(nwstats = NULL, transmat = NULL),
+        run = NULL,
+        network = NULL,
+        diss.stats = NULL
+      ),
+      class = "netsim"
+    )
+  }
+
+  x <- make_mod(c(0.1, 0.2), list(c(1, 2), c(3, 4)))
+  y <- make_mod(c(0.3, 0.4), list(c(5, 6), c(7, 8)))
+
+  z <- merge(x, y)
+  d.set <- get_param_set(z)
+
+  expect_equal(z$control$nsims, 4)
+  expect_equal(z$param$random.params.values$act.rate, c(0.1, 0.2, 0.3, 0.4))
+  expect_equal(z$param$random.params.values$dummy.strat.param,
+               list(c(1, 2), c(3, 4), c(5, 6), c(7, 8)))
+  expect_equal(d.set$act.rate, c(0.1, 0.2, 0.3, 0.4))
+  expect_equal(d.set$dummy.strat.param_1, c(1, 3, 5, 7))
+  expect_equal(d.set$dummy.strat.param_2, c(2, 4, 6, 8))
+})
+
 test_that("merge and print work as expected for save.other", {
   skip_on_cran()
   nw <- network_initialize(n = 100)


### PR DESCRIPTION
## Summary

Fixes preservation of per-simulation `random.params` draw metadata after subsetting or merging `netsim` objects.

Previously, `get_sims()` updated `control$nsims` and sliced simulation outputs but left `param$random.params.values` unchanged, causing `get_param_set()` to error or report stale draws. `merge.netsim()` also compared realized random draws when checking parameter compatibility and retained only the first object's draw history. This PR subsets/appends those draw histories correctly and handles one-simulation outputs with vector-valued random parameters.

## Testing

- Targeted `test-get.R`
- Targeted `test-merge.R`
- `R CMD build .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --as-cran --no-manual EpiModel_2.6.1.tar.gz`