### PR TITLE
Address doc clarity for accessor functions

### DIFF
--- a/R/net.fn.accessor.R
+++ b/R/net.fn.accessor.R
@@ -3,7 +3,12 @@
 #' @description These `get_`, `set_`, `append_`, and `add_`
 #'              functions allow a safe and efficient way to retrieve and mutate
 #'              the main `netsim_dat` class object of network models
-#'              (typical variable name `dat`).
+#'              (typical variable name `dat`). They are intended for use
+#'              *inside module functions* that run during a [netsim()]
+#'              simulation, not for editing the user-facing `param.net`,
+#'              `init.net`, or `control.net` inputs before a run or the
+#'              output object returned by [netsim()]. See the **Intended
+#'              Usage** section below for details and alternatives.
 #'
 #' @inheritParams recovery.net
 #' @param item A character vector containing the name of the element to access
@@ -29,6 +34,41 @@
 #' @return A vector or a list of vectors for `get_` functions; the main
 #'         list object for `set_`, `append_`, and `add_`
 #'         functions.
+#'
+#' @section Intended Usage:
+#' These accessors operate on the live `netsim_dat` object that EpiModel
+#' constructs internally when a simulation starts and passes through each
+#' module at every time step. The expected calling context is **inside a
+#' user-supplied module function** (e.g., a custom `infection.FUN`,
+#' `recovery.FUN`, or arrivals/departures module) registered with
+#' [control.net()].
+#'
+#' They are *not* a general-purpose tool for editing the user-facing input
+#' or output objects of [netsim()]:
+#'
+#'  * Calling them on a [param.net()], [init.net()], or [control.net()]
+#'    object before a run will appear to succeed (those objects are also
+#'    list-like) but produces an object that is not a valid simulation
+#'    input.
+#'  * Calling them on the object returned by [netsim()] modifies only the
+#'    saved input slot, not anything that would change the result of a
+#'    re-run. Note also that [netsim()] strips the `*.FUN` entries from
+#'    its returned `control` slot, so feeding that slot back into a new
+#'    simulation will fail.
+#'
+#' For modifications outside a running simulation, use the following
+#' instead:
+#'
+#'  * **Editing parameters before a run:** [update_params()] for a
+#'    `param.net` object, or direct list assignment
+#'    (e.g., `p$inf.prob <- 0.5`).
+#'  * **Editing init or control before a run:** direct list assignment
+#'    (e.g., `ctrl$nsteps <- 1000`), or rebuild with a fresh call to the
+#'    [init.net()] / [control.net()] constructor.
+#'  * **Scheduled mid-simulation changes:** the `.param.updater.list`
+#'    argument to [param.net()] and the `.control.updater.list` argument
+#'    to [control.net()]. See the "model-parameters" vignette for the
+#'    underlying updater module and the scenario API built on top of it.
 #'
 #' @section Core Attribute:
 #' The `append_core_attr` function initializes the attributes necessary for
@@ -90,6 +130,10 @@
 #' get_control_list(dat)
 #' get_control_list(dat, c("x", "y"))
 #' get_control(dat, "x")
+#'
+#' @seealso [update_params()] for editing a `param.net` object outside a
+#'   simulation; [param.net()], [init.net()], [control.net()] for input
+#'   constructors; [netsim()] for running a simulation.
 #'
 #' @name net-accessor
 NULL

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -293,9 +293,25 @@ param.net <- function(inf.prob, inter.eff, inter.start, act.rate, rec.rate,
 #' original parameter values will be replaced) or not matching (in which case
 #' new parameters will be added to `param`).
 #'
+#' `update_params` modifies a `param.net` object **before** it is passed
+#' to [netsim()]; it is the recommended helper for tweaking parameters
+#' outside of a running simulation. To modify parameters from *inside* a
+#' module function during a simulation, use [set_param()] on the live
+#' `dat` object instead. There is no analogous `update_controls()` or
+#' `update_inits()` helper: for a `control.net` or `init.net` object,
+#' edit the list directly (e.g., `ctrl$nsteps <- 1000`) or rebuild it
+#' with a fresh call to the constructor. For *scheduled* mid-simulation
+#' changes to parameters or control settings, see the
+#' `.param.updater.list` argument to [param.net()] and the
+#' `.control.updater.list` argument to [control.net()].
+#'
 #' @return
 #' An updated list object of class `param.net`, which can be passed to the
 #' EpiModel function [netsim()].
+#'
+#' @seealso [set_param()] for editing parameters inside a module function
+#'   during a simulation; [param.net()] for the parameter constructor;
+#'   [netsim()] for running a simulation.
 #'
 #' @examples
 #' x <- param.net(inf.prob = 0.5, act.rate = 2)

--- a/man/net-accessor.Rd
+++ b/man/net-accessor.Rd
@@ -122,12 +122,56 @@ functions.
 These \code{get_}, \code{set_}, \code{append_}, and \code{add_}
 functions allow a safe and efficient way to retrieve and mutate
 the main \code{netsim_dat} class object of network models
-(typical variable name \code{dat}).
+(typical variable name \code{dat}). They are intended for use
+\emph{inside module functions} that run during a \code{\link[=netsim]{netsim()}}
+simulation, not for editing the user-facing \code{param.net},
+\code{init.net}, or \code{control.net} inputs before a run or the
+output object returned by \code{\link[=netsim]{netsim()}}. See the \strong{Intended
+Usage} section below for details and alternatives.
 
 This function returns an exhaustive named list of the attributes managed by
 EpiModel itself. It can be used to check the validity of an attributes list
 and of its types.
 }
+\section{Intended Usage}{
+
+These accessors operate on the live \code{netsim_dat} object that EpiModel
+constructs internally when a simulation starts and passes through each
+module at every time step. The expected calling context is \strong{inside a
+user-supplied module function} (e.g., a custom \code{infection.FUN},
+\code{recovery.FUN}, or arrivals/departures module) registered with
+\code{\link[=control.net]{control.net()}}.
+
+They are \emph{not} a general-purpose tool for editing the user-facing input
+or output objects of \code{\link[=netsim]{netsim()}}:
+\itemize{
+\item Calling them on a \code{\link[=param.net]{param.net()}}, \code{\link[=init.net]{init.net()}}, or \code{\link[=control.net]{control.net()}}
+object before a run will appear to succeed (those objects are also
+list-like) but produces an object that is not a valid simulation
+input.
+\item Calling them on the object returned by \code{\link[=netsim]{netsim()}} modifies only the
+saved input slot, not anything that would change the result of a
+re-run. Note also that \code{\link[=netsim]{netsim()}} strips the \verb{*.FUN} entries from
+its returned \code{control} slot, so feeding that slot back into a new
+simulation will fail.
+}
+
+For modifications outside a running simulation, use the following
+instead:
+\itemize{
+\item \strong{Editing parameters before a run:} \code{\link[=update_params]{update_params()}} for a
+\code{param.net} object, or direct list assignment
+(e.g., \code{p$inf.prob <- 0.5}).
+\item \strong{Editing init or control before a run:} direct list assignment
+(e.g., \code{ctrl$nsteps <- 1000}), or rebuild with a fresh call to the
+\code{\link[=init.net]{init.net()}} / \code{\link[=control.net]{control.net()}} constructor.
+\item \strong{Scheduled mid-simulation changes:} the \code{.param.updater.list}
+argument to \code{\link[=param.net]{param.net()}} and the \code{.control.updater.list} argument
+to \code{\link[=control.net]{control.net()}}. See the "model-parameters" vignette for the
+underlying updater module and the scenario API built on top of it.
+}
+}
+
 \section{Core Attribute}{
 
 The \code{append_core_attr} function initializes the attributes necessary for
@@ -195,4 +239,9 @@ get_control_list(dat)
 get_control_list(dat, c("x", "y"))
 get_control(dat, "x")
 
+}
+\seealso{
+\code{\link[=update_params]{update_params()}} for editing a \code{param.net} object outside a
+simulation; \code{\link[=param.net]{param.net()}}, \code{\link[=init.net]{init.net()}}, \code{\link[=control.net]{control.net()}} for input
+constructors; \code{\link[=netsim]{netsim()}} for running a simulation.
 }

--- a/man/update_params.Rd
+++ b/man/update_params.Rd
@@ -33,6 +33,18 @@ The \code{new.param.list} object should be a named list object containing
 named parameters matching those already in \code{x} (in which case those
 original parameter values will be replaced) or not matching (in which case
 new parameters will be added to \code{param}).
+
+\code{update_params} modifies a \code{param.net} object \strong{before} it is passed
+to \code{\link[=netsim]{netsim()}}; it is the recommended helper for tweaking parameters
+outside of a running simulation. To modify parameters from \emph{inside} a
+module function during a simulation, use \code{\link[=set_param]{set_param()}} on the live
+\code{dat} object instead. There is no analogous \code{update_controls()} or
+\code{update_inits()} helper: for a \code{control.net} or \code{init.net} object,
+edit the list directly (e.g., \code{ctrl$nsteps <- 1000}) or rebuild it
+with a fresh call to the constructor. For \emph{scheduled} mid-simulation
+changes to parameters or control settings, see the
+\code{.param.updater.list} argument to \code{\link[=param.net]{param.net()}} and the
+\code{.control.updater.list} argument to \code{\link[=control.net]{control.net()}}.
 }
 \examples{
 x <- param.net(inf.prob = 0.5, act.rate = 2)
@@ -40,4 +52,9 @@ y <- list(inf.prob = 0.75, dx.rate = 0.2)
 z <- update_params(x, y)
 print(z)
 
+}
+\seealso{
+\code{\link[=set_param]{set_param()}} for editing parameters inside a module function
+during a simulation; \code{\link[=param.net]{param.net()}} for the parameter constructor;
+\code{\link[=netsim]{netsim()}} for running a simulation.
 }


### PR DESCRIPTION
## Summary

Clarifies the intended scope of the `get_*` / `set_*` / `add_*` / `append_*` accessor functions and of `update_params()`, motivated by #1024.

The functions are designed to operate on the live `netsim_dat` object that `netsim()` constructs internally and passes through user-supplied module functions at every time step. They are not a general-purpose tool for editing user-facing `param.net` / `init.net` / `control.net` inputs before a run, nor for editing the object returned by `netsim()`. Applying them outside that context (as in the example in #1024) appears to succeed because everything is list-like, but it produces an object that isn't a valid simulation input. The behavior is intentional and consistent across the whole accessor family, but the docs never said so explicitly.

This PR is documentation-only.

## Changes

- `R/net.fn.accessor.R`
  - One-sentence pointer added to `@description` flagging the intended scope.
  - New `@section Intended Usage:` covering: the expected calling context (inside module functions during a `netsim()` run); what *not* to call these on (input or output objects); and the right alternatives for the common outside-simulation needs (`update_params()`, direct list assignment, fresh constructor calls) and for scheduled mid-simulation changes (`.param.updater.list` / `.control.updater.list`, scenario API).
  - `@seealso` cross-referencing `update_params()`, the input constructors, and `netsim()`.
- `R/net.inputs.R`
  - `update_params()` `@details` extended to contrast outside-simulation use (`update_params`) with inside-module use (`set_param`); notes the lack of `update_controls()` / `update_inits()` siblings and points at `.param.updater.list` / `.control.updater.list` for mid-simulation changes.
  - `@seealso` added.
- `man/net-accessor.Rd` and `man/update_params.Rd` regenerated via `roxygen2::roxygenise()`.

## Test plan

- [x] CI: `R CMD check --as-cran` passes (doc-only change, but confirms cross-references and Rd render).
- [x] Spot-check rendered help: `?\`net-accessor\`` shows the new Intended Usage section; `?update_params` shows the new details paragraph and Seealso block.

Closes #1024 once merged.