### PR TITLE
Add messages to `make_module_list`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,3 +70,4 @@ LinkingTo: Rcpp, ergm
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## EpiModel 2.6.2
+
+### BREAKING CHANGES
+
+### BUG FIXES
+
+### OTHER
+
+- Increase `make_module_list` verbosity. It now `message`s if `control$module.order` is not provided and list the modules and there order.
+
 ## EpiModel 2.6.1
 
 ### BREAKING CHANGES

--- a/R/net.fn.modules.R
+++ b/R/net.fn.modules.R
@@ -33,6 +33,8 @@ make_module_list <- function(dat) {
   ## Module order
   morder <- get_control(dat, "module.order", override.null.error = TRUE)
   if (is.null(morder)) {
+    message("No `module.order` control found.\n",
+            "The ordering of the arguments to `contro.net` will be used.")
     bi.mods <- get_control(dat, "bi.mods")
     user.mods <- get_control(dat, "user.mods")
     lim.bi.mods <- bi.mods[
@@ -48,6 +50,9 @@ make_module_list <- function(dat) {
   }
   names(modules) <- morder
   dat <- set_modules(dat, modules)
+
+  message("The modules will be run in the following order:\n",
+          paste0("  - `", morder, "`\n"))
 
   return(dat)
 }

--- a/R/net.fn.modules.R
+++ b/R/net.fn.modules.R
@@ -33,8 +33,10 @@ make_module_list <- function(dat) {
   ## Module order
   morder <- get_control(dat, "module.order", override.null.error = TRUE)
   if (is.null(morder)) {
-    message("No `module.order` control found.\n",
-            "The ordering of the arguments to `contro.net` will be used.")
+    if (get_control(dat, "verbose")) {
+      message("No `module.order` control found.\n",
+              "The ordering of the arguments to `contro.net` will be used.")
+    }
     bi.mods <- get_control(dat, "bi.mods")
     user.mods <- get_control(dat, "user.mods")
     lim.bi.mods <- bi.mods[
@@ -51,8 +53,10 @@ make_module_list <- function(dat) {
   names(modules) <- morder
   dat <- set_modules(dat, modules)
 
-  message("The modules will be run in the following order:\n",
-          paste0("  - `", morder, "`\n"))
+  if (get_control(dat, "verbose")) {
+    message("The modules will be run in the following order:\n",
+            paste0("  - `", morder, "`\n"))
+  }
 
   return(dat)
 }

--- a/man/EpiModel-package.Rd
+++ b/man/EpiModel-package.Rd
@@ -151,7 +151,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Samuel Jenness \email{samuel.m.jenness@emory.edu}
   \item Steven M. Goodreau \email{goodreau@uw.edu}
   \item Martina Morris \email{morrism@uw.edu}
   \item Adrien Le Guillou \email{contact@aleguillou.org}

--- a/man/as.phylo.transmat.Rd
+++ b/man/as.phylo.transmat.Rd
@@ -27,7 +27,7 @@ function into a \code{phylo} class object.
 }
 \details{
 Converts a \code{\link[=transmat]{transmat()}} object containing information about the
-history of a simulated infection into a \code{\link[ape:phylo]{ape::phylo}} object
+history of a simulated infection into a \code{\link[ape:read.tree]{ape::phylo}} object
 representation suitable for plotting as a tree with
 \code{\link[ape:plot.phylo]{ape::plot.phylo()}}. Each infection event becomes a 'node'
 (horizontal branch) in the resulting \code{phylo} tree, and each network

--- a/man/brewer_ramp.Rd
+++ b/man/brewer_ramp.Rd
@@ -9,7 +9,7 @@ brewer_ramp(n, plt, delete.lights = TRUE)
 \arguments{
 \item{n}{Number of colors to return.}
 
-\item{plt}{\code{RColorBrewer} palette from \code{\link[RColorBrewer:brewer.pal]{RColorBrewer::brewer.pal}}.}
+\item{plt}{\code{RColorBrewer} palette from \code{\link[RColorBrewer:ColorBrewer]{RColorBrewer::brewer.pal}}.}
 
 \item{delete.lights}{If TRUE, delete the lightest colors from the color
 palette; this helps with plotting in many high-contrast palettes.}
@@ -41,7 +41,7 @@ for (i in seq_along(pals)) {
 
 }
 \seealso{
-\link[RColorBrewer:RColorBrewer]{RColorBrewer::RColorBrewer}
+\link[RColorBrewer:ColorBrewer]{RColorBrewer::RColorBrewer}
 }
 \keyword{colorUtils}
 \keyword{internal}

--- a/man/netdx.Rd
+++ b/man/netdx.Rd
@@ -116,7 +116,7 @@ Models fit with the full STERGM method in \code{netest} (setting the
 simulations may be set using \code{set.control.tergm} in \code{netdx}.
 The parameters should be input through the \code{control.simulate.formula.tergm}
 function, with the available parameters listed in the
-\code{\link[tergm:control.simulate.formula.tergm]{tergm::control.simulate.formula.tergm}} help page in the \code{tergm}
+\code{\link[tergm:control.simulate.tergm]{tergm::control.simulate.formula.tergm}} help page in the \code{tergm}
 package.
 
 Models fit with the ERGM method with the edges dissolution approximation
@@ -127,10 +127,10 @@ simulating that static network forward through time. Control parameters may
 be set for both processes in \code{netdx}. For the first, the parameters
 should be input through the \code{control.simulate.formula()} function, with
 the available parameters listed in the
-\code{\link[ergm:control.simulate.formula]{ergm::control.simulate.formula}} help
+\code{\link[ergm:control.simulate.ergm]{ergm::control.simulate.formula}} help
 page in the \code{ergm} package. For the second, parameters should be input
 through the \code{control.simulate.formula.tergm()} function, with the
-available parameters listed in the \code{\link[tergm:control.simulate.formula.tergm]{tergm::control.simulate.formula.tergm}}
+available parameters listed in the \code{\link[tergm:control.simulate.tergm]{tergm::control.simulate.formula.tergm}}
 help page in the \code{tergm} package. An example is shown below.
 }
 

--- a/man/netest.Rd
+++ b/man/netest.Rd
@@ -30,7 +30,7 @@ indicating an \code{ergm.ego} fit.}
 the network should be reproduced by the model. Common terms include
 \code{edges} (overall connectivity), \code{nodematch} (homophily by attribute),
 \code{concurrent} (overlapping partnerships), and \code{degree} (degree
-distribution constraints). See \code{\link[ergm:ergm-terms]{ergm::ergm-terms}} for the full
+distribution constraints). See \code{\link[ergm:ergmTerm]{ergm::ergm-terms}} for the full
 list of available terms.}
 
 \item{target.stats}{Vector of target statistics for the formation model, with

--- a/man/plot.dcm.Rd
+++ b/man/plot.dcm.Rd
@@ -39,7 +39,7 @@
 
 \item{col}{Color for lines, either specified as a single color in a standard
 R color format, or alternatively as a color palette from
-\link[RColorBrewer:RColorBrewer]{RColorBrewer::RColorBrewer} (see details).}
+\link[RColorBrewer:ColorBrewer]{RColorBrewer::RColorBrewer} (see details).}
 
 \item{lwd}{Line width for output lines.}
 
@@ -110,10 +110,10 @@ size.
 
 Since \code{\link[=dcm]{dcm()}} supports multiple run sensitivity models, plotting
 the results of such models uses a complex color scheme for distinguishing
-runs. This is accomplished using the \code{\link[RColorBrewer:RColorBrewer]{RColorBrewer::RColorBrewer}} color
+runs. This is accomplished using the \code{\link[RColorBrewer:ColorBrewer]{RColorBrewer::RColorBrewer}} color
 palettes, which include a range of linked colors using named palettes. For
 \code{plot.dcm}, one may either specify a brewer color palette listed in
-\code{\link[RColorBrewer:brewer.pal.info]{RColorBrewer::brewer.pal.info}}, or, alternatively, a vector of standard R
+\code{\link[RColorBrewer:ColorBrewer]{RColorBrewer::brewer.pal.info}}, or, alternatively, a vector of standard R
 colors (named, hexidecimal, or positive integers; see \code{\link[=col2rgb]{col2rgb()}}).
 }
 
@@ -155,6 +155,6 @@ plot(mod, y = c("s.num", "i.num"),
 
 }
 \seealso{
-\code{\link[=dcm]{dcm()}}, \code{\link[RColorBrewer:brewer.pal.info]{RColorBrewer::brewer.pal.info}}
+\code{\link[=dcm]{dcm()}}, \code{\link[RColorBrewer:ColorBrewer]{RColorBrewer::brewer.pal.info}}
 }
 \keyword{plot}


### PR DESCRIPTION
addresses #988

- Add a message when no `module.order` is found. Allowing easier debugging
- Print the list and order of modules for debugging as well