### PR TITLE
Remove stale ICM custom-module documentation (#1032)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 
 ### OTHER
 
+- Removed stale ICM custom-module / original-model language from `?icm`, `?param.icm`, and `?init.icm` that lingered after #980. The help pages now state plainly that ICMs support the built-in SI, SIR, and SIS disease types only and direct custom-model users to `netsim()` / `control.net(type = NULL, ...)`. Closes #1032.
 - Increase `make_module_list` verbosity. It now `message`s if `control$module.order` is not provided and list the modules and there order.
 - `control.net()` now validates `module.order` at construction time. Entries that don't correspond to a `.FUN` argument supplied to `control.net()` (typos, or names whose function was never passed) now produce a clear error rather than a cryptic NULL-as-function failure at runtime. `initialize.FUN` and `verbose.FUN` are explicitly rejected from `module.order` since they run outside the per-step module loop and would double-execute if included. Additionally, `control.net()` now warns at construction time when a custom `module.order` is set but omits `resim_nets.FUN`, `summary_nets.FUN`, or `nwupdate.FUN` — three built-ins whose absence typically produces silently incorrect simulations rather than visible errors. The warning is suppressed for built-ins that the user has explicitly disabled by passing `NULL`. Resolves the remaining cryptic-error footgun from #988 and the silent-failure surface that motivated #1030.
 

--- a/R/icm.R
+++ b/R/icm.R
@@ -16,14 +16,11 @@
 #' stochastic variation. The stochasticity is inherent in all transition
 #' processes: infection, recovery, and demographics.
 #'
-#' The `icm` function performs modeling of both the base model types
-#' and original models. Base model types include one-group and two-group
-#' models with disease types for Susceptible-Infected (SI),
-#' Susceptible-Infected-Recovered (SIR), and Susceptible-Infected-Susceptible
-#' (SIS). Original models may be built by writing new process modules that
-#' either take the place of existing modules (for example, disease recovery),
-#' or supplement the set of existing processes with a new one contained in an
-#' original module.
+#' The `icm` function supports the built-in SI, SIR, and SIS disease types
+#' only, in one-group or two-group configurations, with or without demography.
+#' For custom or extension epidemic models, use the network model class via
+#' [netsim()] with `control.net(type = NULL, ...)` and user-supplied module
+#' functions.
 #'
 #' @return
 #' A list of class `icm` with the following elements:
@@ -33,9 +30,8 @@
 #'  * **control:** the control settings passed into the model through
 #'        `control`, with additional controls added as necessary.
 #'  * **epi:** a list of data frames, one for each epidemiological
-#'        output from the model. Outputs for base models always include the
-#'        size of each compartment, as well as flows in, out of, and between
-#'        compartments.
+#'        output from the model. Outputs always include the size of each
+#'        compartment, as well as flows in, out of, and between compartments.
 #'
 #'
 #' @keywords model

--- a/R/icm.inputs.R
+++ b/R/icm.inputs.R
@@ -8,12 +8,12 @@
 #'
 #' @details
 #' `param.icm` sets the epidemic parameters for the stochastic individual
-#' contact models simulated with the [icm()] function. Models
-#' may use the base types, for which these parameters are used, or new process
-#' modules which may use these parameters (but not necessarily).
+#' contact models simulated with the [icm()] function. ICMs support the
+#' built-in SI, SIR, and SIS disease types only; for custom or extension
+#' epidemic models, use [param.net()] with the network model class.
 #'
-#' For base models, the model specification will be chosen as a result of
-#' the model parameters entered here and the control settings in
+#' The model specification will be chosen as a result of the model parameters
+#' entered here and the control settings in
 #' [control.icm()]. One-group and two-group models are available,
 #' where the former assumes a homogeneous mixing in the population and the
 #' latter assumes some form of heterogeneous mixing between two distinct
@@ -111,7 +111,8 @@ param.icm <- function(inf.prob, inter.eff, inter.start, act.rate, rec.rate,
 #' @details
 #' The initial conditions for a model solved with [icm()] should be
 #' input into the `init.icm` function. This function handles initial
-#' conditions for both base models and original models using new modules.
+#' conditions for the built-in SI, SIR, and SIS disease types; for custom or
+#' extension epidemic models, use [init.net()] with the network model class.
 #'
 #' @return An `EpiModel` object of class `init.icm`.
 #'

--- a/man/icm.Rd
+++ b/man/icm.Rd
@@ -22,9 +22,8 @@ A list of class \code{icm} with the following elements:
 \item \strong{control:} the control settings passed into the model through
 \code{control}, with additional controls added as necessary.
 \item \strong{epi:} a list of data frames, one for each epidemiological
-output from the model. Outputs for base models always include the
-size of each compartment, as well as flows in, out of, and between
-compartments.
+output from the model. Outputs always include the size of each
+compartment, as well as flows in, out of, and between compartments.
 }
 }
 \description{
@@ -38,14 +37,11 @@ on individual agents in discrete time as a function of processes with
 stochastic variation. The stochasticity is inherent in all transition
 processes: infection, recovery, and demographics.
 
-The \code{icm} function performs modeling of both the base model types
-and original models. Base model types include one-group and two-group
-models with disease types for Susceptible-Infected (SI),
-Susceptible-Infected-Recovered (SIR), and Susceptible-Infected-Susceptible
-(SIS). Original models may be built by writing new process modules that
-either take the place of existing modules (for example, disease recovery),
-or supplement the set of existing processes with a new one contained in an
-original module.
+The \code{icm} function supports the built-in SI, SIR, and SIS disease types
+only, in one-group or two-group configurations, with or without demography.
+For custom or extension epidemic models, use the network model class via
+\code{\link[=netsim]{netsim()}} with \code{control.net(type = NULL, ...)} and user-supplied module
+functions.
 }
 \examples{
 \dontrun{

--- a/man/init.icm.Rd
+++ b/man/init.icm.Rd
@@ -38,7 +38,8 @@ models simulated with \code{icm}.
 \details{
 The initial conditions for a model solved with \code{\link[=icm]{icm()}} should be
 input into the \code{init.icm} function. This function handles initial
-conditions for both base models and original models using new modules.
+conditions for the built-in SI, SIR, and SIS disease types; for custom or
+extension epidemic models, use \code{\link[=init.net]{init.net()}} with the network model class.
 }
 \seealso{
 Use \code{\link[=param.icm]{param.icm()}} to specify model parameters and

--- a/man/param.icm.Rd
+++ b/man/param.icm.Rd
@@ -109,12 +109,12 @@ models simulated with \code{icm}.
 }
 \details{
 \code{param.icm} sets the epidemic parameters for the stochastic individual
-contact models simulated with the \code{\link[=icm]{icm()}} function. Models
-may use the base types, for which these parameters are used, or new process
-modules which may use these parameters (but not necessarily).
+contact models simulated with the \code{\link[=icm]{icm()}} function. ICMs support the
+built-in SI, SIR, and SIS disease types only; for custom or extension
+epidemic models, use \code{\link[=param.net]{param.net()}} with the network model class.
 
-For base models, the model specification will be chosen as a result of
-the model parameters entered here and the control settings in
+The model specification will be chosen as a result of the model parameters
+entered here and the control settings in
 \code{\link[=control.icm]{control.icm()}}. One-group and two-group models are available,
 where the former assumes a homogeneous mixing in the population and the
 latter assumes some form of heterogeneous mixing between two distinct

--- a/man/param.net.Rd
+++ b/man/param.net.Rd
@@ -185,8 +185,9 @@ parameter meta-data. However, these extra columns will not be used by
 EpiModel.
 
 This data.frame is then passed in to \code{param.net} under a
-\code{data.frame.parameters} argument. Further details and examples are
-provided in the "Working with Model Parameters in EpiModel" vignette.
+\code{data.frame.params} argument (\code{data.frame.parameters} is also accepted as
+a deprecated alias). Further details and examples are provided in the
+"Working with Model Parameters in EpiModel" vignette.
 }
 
 \section{Parameters with New Modules}{


### PR DESCRIPTION
## Summary

Closes #1032.

After #980, ICMs are restricted to the built-in SI, SIR, and SIS disease types, but three help pages still described support for "original models" built from "new process modules":

- `?icm` (`R/icm.R`) — details paragraph about base + original models
- `?param.icm` (`R/icm.inputs.R`) — "Models may use the base types... or new process modules"
- `?init.icm` (`R/icm.inputs.R`) — "handles initial conditions for both base models and original models using new modules"

This PR replaces that language with direct statements that ICMs support SI/SIR/SIS only, and points custom-model users to `netsim()` with `control.net(type = NULL, ...)` (for `?icm`), `param.net()` (for `?param.icm`), and `init.net()` (for `?init.icm`). The wording mirrors the cleanup already done in `?control.icm` and `?modules.icm` in #980.

## Other changes

- Dropped the now-redundant "for base models" qualifier in the `@return` outputs bullet of `?icm` and the second details paragraph of `?param.icm`, since there are no other model types.
- Added a one-line NEWS entry under v2.6.2 → OTHER.
- Re-ran `roxygen2::roxygenise()` to regenerate `man/icm.Rd`, `man/param.icm.Rd`, `man/init.icm.Rd`. The run also picked up `man/param.net.Rd`, which was out of date relative to the current `param.net()` source (the regenerated text matches what `R/net.inputs.R` already says about `data.frame.params` / `data.frame.parameters`).

## Test plan

- [ ] CI green (no code changes, doc-only)
- [ ] Spot-check rendered Rd: `?icm`, `?param.icm`, `?init.icm` no longer reference "original models" or "new process modules"
- [ ] Verify pointers in the new text resolve: `[netsim()]`, `[param.net()]`, `[init.net()]`, `[control.net()]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)