### PR TITLE
Add Correct ylabs to netdx #1051

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ Suggests:
     plotly (>= 4.10.0),
     rmarkdown,
     shiny,
-    testthat,
+    testthat (>= 3.1.8),
     progressr,
     tidyr
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 -   Fix the `cumulative.edgelist` recording of the head and tail of nodes. Previously it was inverted. This had no effect on undirected networks but would on directed ones
 -   Fix `param.net` so that values supplied via `data.frame.params` (notably `act.rate`, and the vital-dynamics parameters `a.rate` / `ds.rate` / `di.rate` / `dr.rate`) are no longer overwritten by the constructor's defaults. Closes #1029 and #1031.
 -   Fix `create_scenario_list` and `generate_random_params` so they no longer fail when their input `data.frame` (a `scenarios.df`, or a `param.random.set`) contains a single parameter column. Closes #1045.
+-   Fix the y-axis labels on `plot.netdx()`. The `duration` and `dissolution` plots now default to "Mean Age of Active Ties" and "Proportion of Ties Dissolved" rather than the statistic name. `xlab` and `ylab` are also now honored for `method = "b"`, where they were previously dropped, in both `plot.netdx()` and `plot.netsim(type = "formation")`. Boxplot axes take their own defaults, since their x axis is categorical (one box per statistic) rather than time. Closes #1051.
 
 ### OTHER
 

--- a/R/plot.netdx.R
+++ b/R/plot.netdx.R
@@ -158,13 +158,11 @@ plot.netdx <- function(x, type = "formation", method = "l", sims = NULL,
     if (type == "duration") {
       data <- if (duration.imputed) x$pages_imptd else x$pages
       stats_table <- x$stats.table.duration
-      if (is.null(ylab))
-        ylab <- "Mean Age of Active Ties"
+      ylab <- NVL(ylab, "Mean Age of Active Ties")
     } else { # if type is "dissolution"
       data <- x$prop.diss
       stats_table <- x$stats.table.dissolution
-      if (is.null(ylab))
-        ylab <- "Fraction of Ties Dissolved"
+      ylab <- NVL(ylab, "Proportion of Ties Dissolved")
     }
   }
 

--- a/R/plot.netdx.R
+++ b/R/plot.netdx.R
@@ -158,9 +158,13 @@ plot.netdx <- function(x, type = "formation", method = "l", sims = NULL,
     if (type == "duration") {
       data <- if (duration.imputed) x$pages_imptd else x$pages
       stats_table <- x$stats.table.duration
+      if (is.null(ylab))
+        ylab <- "Mean Age of Active Ties"
     } else { # if type is "dissolution"
       data <- x$prop.diss
       stats_table <- x$stats.table.dissolution
+      if (is.null(ylab))
+        ylab <- "Fraction of Ties Dissolved"
     }
   }
 

--- a/R/plot.stat_table.R
+++ b/R/plot.stat_table.R
@@ -16,6 +16,32 @@ validate_stats_selection <- function(stats_table, data, stats,
   list(data = data, nmstats = nmstats, targets = targets)
 }
 
+## Axis label defaults for `plot_stats_table`.
+##
+## Line plots are drawn over time (or over simulation number, when static), and
+## when `plots.joined` is FALSE each statistic gets its own panel titled with
+## the statistic name, so the shared axis labels are dropped.
+##
+## Box plots differ on both counts. Their x axis is categorical, with one box
+## per statistic, so labeling it "time" would be wrong. They are also always a
+## single panel, so `plots.joined` does not apply to them and must not blank out
+## a caller-supplied label.
+stats_plot_labs <- function(method, plots.joined, dynamic, nstats, nmstats,
+                            xlab = NULL, ylab = NULL) {
+  default.ylab <- if (nstats == 1) nmstats else "Statistic"
+
+  if (method == "b") {
+    return(list(xlab = NVL(xlab, ""), ylab = NVL(ylab, default.ylab)))
+  }
+
+  default.xlab <- if (isTRUE(dynamic)) "time" else "simulation number"
+
+  list(
+    xlab = if (isFALSE(plots.joined)) "" else NVL(xlab, default.xlab),
+    ylab = if (isFALSE(plots.joined)) "" else NVL(ylab, default.ylab)
+  )
+}
+
 plot_stats_table <- function(data, nmstats, method,
                              sim.lines,
                              sim.col = NULL, sim.lwd = NULL, mean.line,
@@ -42,8 +68,10 @@ plot_stats_table <- function(data, nmstats, method,
 
   xlim <- NVL(xlim, c(1, dim(data)[1]))
 
-  xlab <- if (isFALSE(plots.joined)) "" else NVL(xlab, if (isTRUE(dynamic)) "time" else "simulation number")
-  ylab <- if (isFALSE(plots.joined)) "" else NVL(ylab, if (nstats == 1) nmstats else "Statistic")
+  labs <- stats_plot_labs(method, plots.joined, dynamic, nstats, nmstats,
+                          xlab, ylab)
+  xlab <- labs$xlab
+  ylab <- labs$ylab
 
   if (is.null(sim.lwd)) {
     if (dim(data)[3] > 1) {

--- a/R/plot.stat_table.R
+++ b/R/plot.stat_table.R
@@ -228,7 +228,7 @@ plot_stats_table <- function(data, nmstats, method,
     data <- matrix(aperm(data, c(1, 3, 2)), nrow = dim(data)[1] * dim(data)[3])
     colnames(data) <- nmstats
 
-    boxplot(data, ...)
+    boxplot(data, xlab = xlab, ylab = ylab, ...)
 
     for (j in seq_len(nstats)) {
       points(x = j, y = targets[j],

--- a/tests/testthat/test-netdx.R
+++ b/tests/testthat/test-netdx.R
@@ -402,3 +402,79 @@ test_that("make_stats_table behaves as expected", {
   expect_equal(mst[["Target"]], targs)
   expect_equal(mst[["Pct Diff"]], 100*((stats_1 + stats_2)/2 - targs)/targs)
 })
+
+test_that("stats_plot_labs sets axis label defaults", {
+  # Line plots run over time, or over simulation number when static
+  expect_equal(
+    stats_plot_labs("l", TRUE, TRUE, 1, "edges"),
+    list(xlab = "time", ylab = "edges")
+  )
+  expect_equal(
+    stats_plot_labs("l", TRUE, FALSE, 2, c("edges", "concurrent")),
+    list(xlab = "simulation number", ylab = "Statistic")
+  )
+
+  # Separate panels are titled by statistic, so shared labels are dropped
+  expect_equal(
+    stats_plot_labs("l", FALSE, TRUE, 4, letters[1:4]),
+    list(xlab = "", ylab = "")
+  )
+
+  # Box plots have a categorical x axis and are always a single panel, so
+  # they never take the "time" default and never blank labels out
+  expect_equal(
+    stats_plot_labs("b", TRUE, TRUE, 1, "edges"),
+    list(xlab = "", ylab = "edges")
+  )
+  expect_equal(
+    stats_plot_labs("b", FALSE, TRUE, 4, letters[1:4]),
+    list(xlab = "", ylab = "Statistic")
+  )
+  expect_equal(
+    stats_plot_labs("b", FALSE, TRUE, 4, letters[1:4], "My X", "My Y"),
+    list(xlab = "My X", ylab = "My Y")
+  )
+
+  # Caller-supplied labels always win where labels are drawn at all
+  expect_equal(
+    stats_plot_labs("l", TRUE, TRUE, 1, "edges", "My X", "My Y"),
+    list(xlab = "My X", ylab = "My Y")
+  )
+})
+
+test_that("plot.netdx labels duration and dissolution axes", {
+  skip_on_cran()
+
+  nw <- network_initialize(n = 50)
+  coef.diss <- dissolution_coefs(dissolution = ~offset(edges), duration = 20)
+  est <- netest(nw, ~edges, 15, coef.diss, verbose = FALSE)
+  dx <- netdx(est, nsims = 1, nsteps = 10, verbose = FALSE)
+
+  # Capture what the box plot method is handed, rather than drawing it
+  seen <- NULL
+  local_mocked_bindings(
+    boxplot = function(x, ...) {
+      seen <<- list(...)
+      invisible(NULL)
+    },
+    points = function(...) invisible(NULL),
+    .package = "EpiModel"
+  )
+
+  plot(dx, type = "duration", method = "b")
+  expect_equal(seen$xlab, "")
+  expect_equal(seen$ylab, "Mean Age of Active Ties")
+
+  plot(dx, type = "dissolution", method = "b")
+  expect_equal(seen$xlab, "")
+  expect_equal(seen$ylab, "Proportion of Ties Dissolved")
+
+  plot(dx, type = "formation", method = "b")
+  expect_equal(seen$xlab, "")
+  expect_equal(seen$ylab, "edges")
+
+  # Caller-supplied labels reach the box plot method
+  plot(dx, type = "duration", method = "b", xlab = "My X", ylab = "My Y")
+  expect_equal(seen$xlab, "My X")
+  expect_equal(seen$ylab, "My Y")
+})


### PR DESCRIPTION
Fixes #1051

Add y-axis label for netdx duration and dissolution plots. 
Also forward the axis arguments to the boxplot method

```r
    num <- 50
    nw <- network_initialize(n = num)
    formation <- ~edges
    target.stats <- 15
    coef.diss <- dissolution_coefs(dissolution = ~offset(edges), duration = 20)
    est1 <- netest(nw, formation, target.stats, coef.diss, verbose = FALSE)
    dx1 <- netdx(est1, nsims = 1, nsteps = 10, verbose = FALSE)
    
    par(mfrow = c(2, 2))
    plot(dx1, type = "duration", mean.smooth = FALSE)
    plot(dx1, method = "b", type = "duration")
    plot(dx1, type = "dissolution")
    plot(dx1, method = "b", type = "dissolution")
```


<img width="1200" height="990" alt="image" src="https://github.com/user-attachments/assets/1b66c6f0-1e4c-4687-aa1c-b9076ec1a804" />
