### PR TITLE
Add get_degree_dist to the pkgdown reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -87,6 +87,7 @@ reference:
       - set_vertex_attribute
       - netest
       - netdx
+      - get_degree_dist
       - dissolution_coefs
       - update_dissolution
       - trim_netest


### PR DESCRIPTION
Fixes the pkgdown build on main, which has failed since #1066 merged ([run 30947521407](https://github.com/EpiModel/EpiModel/actions/runs/30947521407/job/92121077909)):

```
Error in `build_reference_index()`:
! In _pkgdown.yml, 1 topic missing from index: "get_degree_dist".
```

`_pkgdown.yml` enumerates every exported topic, so a new export has to be added there or the reference index build aborts. `get_degree_dist` goes next to `netdx` under "Network Model Setup & Estimation": it reads the timed edgelist of a `netdx` object and is the data behind `plot.netdx(type = "cumldeg")`. My oversight in #1066.

The two internal helpers that came with it, `tedgelist_cumulative_degree` and `tedgelist_momentary_degree`, carry `@keywords internal` and are correctly excluded, which is why pkgdown flagged only the one topic.

Verified locally: `pkgdown::check_pkgdown()` reports no problems, and `build_reference(topics = c("get_degree_dist", "plot.netdx"))` renders both pages, which also runs the `get_degree_dist` examples since pkgdown evaluates `\donttest` blocks. The rest of that example set is `\dontrun` and is not evaluated.

None of the other open PRs add an exported topic, so this should be the only index gap in the current batch.