### PR TITLE
Add the regression coverage missing from the v2.6.2 review

### DIFF
--- a/tests/testthat/test-cumulative_edgelist.R
+++ b/tests/testthat/test-cumulative_edgelist.R
@@ -316,3 +316,96 @@ test_that("netsim, SI, Cumulative Edgelist with arrivals and departures", {
   expect_true(all(get_posit_ids(dat, unique(partners$index)) %in% spids))
 
 })
+
+context("Cumulative Edgelist: head/tail orientation")
+
+# (t)ergm edgelists carry the tail in column 1 and the head in column 2. The
+# cumulative edgelist recorded them the other way round (#1021). On an
+# undirected network the stored dyad is sorted, so the inversion is invisible;
+# it only changes the output for a directed one. EpiModel simulates undirected
+# networks only, so these drive the recorders directly with edgelists whose two
+# columns are distinguishable. Cheap and deterministic, so not skipped on CRAN.
+
+test_that("update_cumulative_edgelist takes tail from column 1 (#1021)", {
+  dat <- create_dat_object(
+    control = list(tergmLite = TRUE, cumulative.edgelist = TRUE,
+                   truncate.el.cuml = Inf)
+  )
+  dat <- append_core_attr(dat, 1, 8)
+  dat$num.nw <- 1
+  # Every row runs high -> low or low -> high, so an inversion cannot pass.
+  dat$run$el <- list(matrix(c(5L, 3L,
+                              2L, 6L), ncol = 2, byrow = TRUE))
+  dat <- set_current_timestep(dat, 4)
+
+  dat <- update_cumulative_edgelist(dat, 1, truncate = Inf)
+  el <- get_cumulative_edgelist(dat, 1)
+
+  expect_equal(el$tail, c(5, 2))
+  expect_equal(el$head, c(3, 6))
+  expect_equal(el$start, c(4, 4))
+})
+
+test_that("cumulative edgelist preserves direction on a directed network (#1021)", {
+  # The non-tergmLite path reads its dyads from the networkDynamic object, so
+  # this one can use a genuinely directed network rather than a bare matrix.
+  nw <- network::network.initialize(8, directed = TRUE)
+  nwd <- networkDynamic(
+    base.net = nw,
+    edge.spells = data.frame(onset = 0, terminus = Inf,
+                             tail = c(5, 2), head = c(3, 6)),
+    verbose = FALSE
+  )
+
+  dat <- create_dat_object(
+    control = list(tergmLite = FALSE, cumulative.edgelist = TRUE,
+                   truncate.el.cuml = Inf)
+  )
+  dat <- append_core_attr(dat, 1, 8)
+  dat$num.nw <- 1
+  dat$run$nw <- list(nwd)
+  dat <- set_current_timestep(dat, 4)
+
+  dat <- update_cumulative_edgelist(dat, 1, truncate = Inf)
+  el <- get_cumulative_edgelist(dat, 1)
+
+  # Same dyads as the network was given them, not transposed.
+  expect_equal(el$tail, c(5, 2))
+  expect_equal(el$head, c(3, 6))
+})
+
+test_that("seed_cumulative_edgelist_t1 keeps orientation in all branches (#1021)", {
+  # The seed writes head/tail in three places: edges present at both t=0 and
+  # t=1, edges new at t=1, and edges dropped after t=0. All three were
+  # inverted, so all three are checked.
+  dat <- create_dat_object(
+    control = list(tergmLite = TRUE, cumulative.edgelist = TRUE,
+                   truncate.el.cuml = Inf)
+  )
+  dat <- append_core_attr(dat, 1, 8)
+  dat$num.nw <- 1
+  # 5 -> 3 persists, 2 -> 6 is dropped after t=0, 7 -> 1 forms at t=1.
+  dat$run$el_t0_seed <- list(matrix(c(5L, 3L,
+                                      2L, 6L), ncol = 2, byrow = TRUE))
+  dat$run$el <- list(matrix(c(5L, 3L,
+                              7L, 1L), ncol = 2, byrow = TRUE))
+
+  dat <- seed_cumulative_edgelist_t1(dat)
+  el <- get_cumulative_edgelist(dat, 1)
+
+  expect_setequal(paste(el$tail, el$head, sep = "->"),
+                  c("5->3", "2->6", "7->1"))
+
+  persistent <- el[el$tail == 5, ]
+  expect_equal(persistent$head, 3)
+  expect_equal(persistent$start, 0)
+  expect_true(is.na(persistent$stop))
+
+  new_edge <- el[el$tail == 7, ]
+  expect_equal(new_edge$head, 1)
+  expect_equal(new_edge$start, 1)
+
+  dropped <- el[el$tail == 2, ]
+  expect_equal(dropped$head, 6)
+  expect_equal(c(dropped$start, dropped$stop), c(0, 0))
+})

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -59,8 +59,11 @@ test_that("get_network.netsim rejects collapse / at under tergmLite", {
   est_tl <- netest(nw, formation = ~edges, target.stats = 25,
                    coef.diss = dissolution_coefs(~offset(edges), 10, 0),
                    verbose = FALSE)
-  control_tl <- control.net(type = "SI", nsteps = 5, nsims = 1,
-                            tergmLite = TRUE, verbose = FALSE)
+  expect_warning(
+    control_tl <- control.net(type = "SI", nsteps = 5, nsims = 1,
+                              tergmLite = TRUE, verbose = FALSE),
+    "resetting resimulate.network"
+  )
   mod_tl <- netsim(est_tl, param.net(inf.prob = 0.3),
                    init.net(i.num = 5), control_tl)
 

--- a/tests/testthat/test-net-inputs-validation.R
+++ b/tests/testthat/test-net-inputs-validation.R
@@ -69,6 +69,36 @@ test_that("param.net warns on act.rate.g2", {
                  "act.rate.g2.*only act.rate parameter will apply")
 })
 
+test_that("control.net warns and resets resimulate.network under tergmLite", {
+  # tergmLite cannot hold a network fixed across steps, so the combination is
+  # silently corrected. The warning is expected, and several test files trip
+  # it; asserting it here is what makes those wrappers meaningful rather than
+  # noise. Also covers the case where resimulate.network is simply left out.
+  expect_warning(
+    ctrl <- control.net(type = "SI", nsteps = 5, resimulate.network = FALSE,
+                        tergmLite = TRUE, verbose = FALSE),
+    "Because tergmLite = TRUE, resetting resimulate.network = TRUE"
+  )
+  expect_true(ctrl$resimulate.network)
+
+  expect_warning(
+    ctrl <- control.net(type = "SI", nsteps = 5, tergmLite = TRUE,
+                        verbose = FALSE),
+    "resetting resimulate.network"
+  )
+  expect_true(ctrl$resimulate.network)
+
+  # No warning when the two settings already agree, or when tergmLite is off.
+  expect_silent(ctrl <- control.net(type = "SI", nsteps = 5, tergmLite = TRUE,
+                                    resimulate.network = TRUE, verbose = FALSE))
+  expect_true(ctrl$resimulate.network)
+
+  expect_silent(ctrl <- control.net(type = "SI", nsteps = 5, tergmLite = FALSE,
+                                    resimulate.network = FALSE,
+                                    verbose = FALSE))
+  expect_false(ctrl$resimulate.network)
+})
+
 test_that("generate_random_params validates random.params structure", {
   # random.params validation runs at simulation time, inside
   # generate_random_params(). Calling that function directly lets us hit

--- a/tests/testthat/test-net-tergmLite.R
+++ b/tests/testthat/test-net-tergmLite.R
@@ -15,8 +15,11 @@ test_that("tergmLite: 1G, Closed", {
 
   param <- param.net(inf.prob = 0.1, act.rate = 5)
   init <- init.net(i.num = 10)
-  control <- control.net(type = "SI", nsteps = 20, nsims = 1, ncores = 1,
-                         resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE)
+  expect_warning(
+    control <- control.net(type = "SI", nsteps = 20, nsims = 1, ncores = 1,
+                           resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE),
+    "resetting resimulate.network"
+  )
 
   sim <- netsim(est, param, init, control)
   expect_s3_class(sim, "netsim")
@@ -28,8 +31,11 @@ test_that("tergmLite: 1G, Closed", {
   # SIS
   param <- param.net(inf.prob = 0.5, act.rate = 1, rec.rate = 0.02)
   init <- init.net(i.num = 10)
-  control <- control.net(type = "SIS", nsteps = 10, nsims = 1, ncores = 1,
-                         resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE)
+  expect_warning(
+    control <- control.net(type = "SIS", nsteps = 10, nsims = 1, ncores = 1,
+                           resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE),
+    "resetting resimulate.network"
+  )
 
   sim <- netsim(est, param, init, control)
   expect_s3_class(sim, "netsim")
@@ -41,8 +47,11 @@ test_that("tergmLite: 1G, Closed", {
   # SIR
   param <- param.net(inf.prob = 0.5, act.rate = 1, rec.rate = 0.02)
   init <- init.net(i.num = 10, r.num = 5)
-  control <- control.net(type = "SIR", nsteps = 10, nsims = 1, ncores = 1,
-                         resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE)
+  expect_warning(
+    control <- control.net(type = "SIR", nsteps = 10, nsims = 1, ncores = 1,
+                           resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE),
+    "resetting resimulate.network"
+  )
 
   sim <- netsim(est, param, init, control)
   expect_s3_class(sim, "netsim")
@@ -67,8 +76,11 @@ test_that("tergmLite: 2G, Closed", {
   # Parameters
   param <- param.net(inf.prob = 0.4, inf.prob.g2 = 0.2)
   init <- init.net(i.num = 20, i.num.g2 = 20)
-  control <- control.net(type = "SI", nsteps = 20, nsims = 1, ncores = 1,
-                         resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE)
+  expect_warning(
+    control <- control.net(type = "SI", nsteps = 20, nsims = 1, ncores = 1,
+                           resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE),
+    "resetting resimulate.network"
+  )
 
   sim <- netsim(est, param, init, control)
   expect_s3_class(sim, "netsim")
@@ -81,8 +93,11 @@ test_that("tergmLite: 2G, Closed", {
   param <- param.net(inf.prob = 0.4, inf.prob.g2 = 0.2,
                      rec.rate = 0.02, rec.rate.g2 = 0.02)
   init <- init.net(i.num = 20, i.num.g2 = 20)
-  control <- control.net(type = "SIS", nsteps = 10, nsims = 1, ncores = 1,
-                         resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE)
+  expect_warning(
+    control <- control.net(type = "SIS", nsteps = 10, nsims = 1, ncores = 1,
+                           resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE),
+    "resetting resimulate.network"
+  )
 
   sim <- netsim(est, param, init, control)
   expect_s3_class(sim, "netsim")
@@ -95,8 +110,11 @@ test_that("tergmLite: 2G, Closed", {
   param <- param.net(inf.prob = 0.4, inf.prob.g2 = 0.2,
                      rec.rate = 0.02, rec.rate.g2 = 0.02)
   init <- init.net(i.num = 10, i.num.g2 = 10, r.num = 5, r.num.g2 = 5)
-  control <- control.net(type = "SIR", nsteps = 10, nsims = 1, ncores = 1,
-                         resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE)
+  expect_warning(
+    control <- control.net(type = "SIR", nsteps = 10, nsims = 1, ncores = 1,
+                           resimulate.network = FALSE, tergmLite = TRUE, verbose = FALSE),
+    "resetting resimulate.network"
+  )
 
   sim <- netsim(est, param, init, control)
   expect_s3_class(sim, "netsim")

--- a/tests/testthat/test-newmodules.R
+++ b/tests/testthat/test-newmodules.R
@@ -351,6 +351,56 @@ test_that("SIS with scenarios", {
   expect_error(sc.param <- use_scenario(param, scenarios.list[[1]]))
 })
 
+test_that("create_scenario_list handles a single parameter column (#1045)", {
+  # Selecting a row of a one-parameter table dropped it to an unnamed scalar,
+  # so `unflatten_params` was handed NULL names and `strsplit` failed with
+  # "non-character argument". No netsim here, so this runs on CRAN too.
+  sc.df <- data.frame(
+    .scenario.id = c("a", "b"),
+    .at          = 0,
+    inf.prob     = c(0.2, 0.3),
+    stringsAsFactors = FALSE
+  )
+
+  sc <- create_scenario_list(sc.df)
+  expect_length(sc, 2)
+  expect_equal(names(sc), c("a", "b"))
+  expect_equal(sc[["a"]][[".param.updater.list"]][[1]]$param,
+               list(inf.prob = 0.2))
+  expect_equal(sc[["b"]][[".param.updater.list"]][[1]]$param,
+               list(inf.prob = 0.3))
+
+  # The value reaches `param` through `use_scenario` as well.
+  param <- param.net(inf.prob = 0.9, act.rate = 2)
+  expect_equal(use_scenario(param, sc[["b"]])$inf.prob, 0.3)
+
+  # Several `.at` rows for one scenario, still one parameter column.
+  sc.df2 <- data.frame(
+    .scenario.id = "ramp",
+    .at          = c(0, 10, 20),
+    inf.prob     = c(0.1, 0.2, 0.3),
+    stringsAsFactors = FALSE
+  )
+  updaters <- create_scenario_list(sc.df2)[["ramp"]][[".param.updater.list"]]
+  expect_length(updaters, 3)
+  expect_equal(vapply(updaters, function(u) u$param$inf.prob, numeric(1)),
+               c(0.1, 0.2, 0.3))
+
+  # A lone column carrying a position suffix rebuilds a length-1 vector.
+  sc.df3 <- data.frame(.scenario.id = "s", .at = 0, d.rate_1 = 0.5,
+                       check.names = FALSE, stringsAsFactors = FALSE)
+  expect_equal(
+    create_scenario_list(sc.df3)[["s"]][[".param.updater.list"]][[1]]$param,
+    list(d.rate = 0.5)
+  )
+
+  # Two parameter columns were never affected; kept as the contrast case.
+  sc.df4 <- data.frame(.scenario.id = "a", .at = 0, inf.prob = 0.2,
+                       act.rate = 1, stringsAsFactors = FALSE)
+  expect_equal(create_scenario_list(sc.df4)[["a"]][[".param.updater.list"]][[1]]$param,
+               list(inf.prob = 0.2, act.rate = 1))
+})
+
 context("Records: attr_history and Raw Objects")
 
 test_that("Time varying elements", {
@@ -795,6 +845,30 @@ test_that("Random parameters generators", {
   randoms <- c(my_randoms, list(param.random.set = list()))
   param <- param.net(inf.prob = 0.3, random.params = randoms)
   expect_error(generate_random_params(param))
+})
+
+test_that("generate_random_params handles a single-column param.random.set (#1045)", {
+  # Same root cause as the scenario path: picking a row of a one-column
+  # `param.random.set` dropped it to an unnamed scalar, so `unflatten_params`
+  # errored on NULL names. No netsim here, so this runs on CRAN too.
+  set.seed(11)
+  prs <- data.frame(tx.halt.prob = c(0.25, 0.5, 0.75))
+  param <- param.net(inf.prob = 0.3,
+                     random.params = list(param.random.set = prs))
+
+  expect_silent(p <- generate_random_params(param))
+  expect_length(p$tx.halt.prob, 1)
+  expect_true(p$tx.halt.prob %in% prs$tx.halt.prob)
+  # The drawn value is also recorded for the run.
+  expect_equal(p$random.params.values, list(tx.halt.prob = p$tx.halt.prob))
+
+  # A lone column carrying a position suffix rebuilds the vector parameter.
+  prs2 <- data.frame(d.rate_1 = c(0.1, 0.2), check.names = FALSE)
+  param2 <- param.net(inf.prob = 0.3,
+                      random.params = list(param.random.set = prs2))
+  p2 <- generate_random_params(param2)
+  expect_length(p2$d.rate, 1)
+  expect_true(p2$d.rate %in% prs2$d.rate_1)
 })
 
 # `module.order` validation (run at control.net() construction time) -----------


### PR DESCRIPTION
Closes #1061, except for the `raw.records` item (see below).

Tests only, no behavior change, so no NEWS entry.

## Untested v2.6.2 fixes

`create_scenario_list()` and `generate_random_params()` on a `data.frame` with a single parameter column (#1045). Row selection dropped the frame to an unnamed scalar, so `unflatten_params()` was handed `NULL` names and `strsplit()` errored with "non-character argument". Covered are the plain one-column table, delivery through `use_scenario()`, several `.at` rows for one scenario, a lone column carrying a `_1` position suffix, and the two-column case as the contrast. Neither needs a `netsim()` run, so both run on CRAN.

Cumulative edgelist head/tail orientation (#1021). One thing to flag here: EpiModel cannot simulate directed networks. `network_initialize()` hardcodes `directed = FALSE` and the custom ERGM terms declare `directed = FALSE`, so adding a directed case to an existing `netsim()` test is not possible. Instead these drive the recorders directly with edgelists whose two columns are distinguishable:

- `update_cumulative_edgelist()` on a `tergmLite` edgelist matrix with rows `5 -> 3` and `2 -> 6`.
- The non-`tergmLite` path against a real directed `networkDynamic` object, which is the case the inversion actually changed.
- `seed_cumulative_edgelist_t1()` across all three of its branches (persistent, new at t=1, dropped after t=0). #1035 fixed the orientation in all three; only one would be exercised otherwise.

All are fast and deterministic, so none are skipped on CRAN.

## Unasserted warnings

The seven `resetting resimulate.network` warnings come from `control.net()` (`R/net.inputs.R:1109`), not from `netsim()`. All seven are now wrapped in `expect_warning()`, six in `test-net-tergmLite.R` and one in `test-get.R`. A new test in `test-net-inputs-validation.R` asserts the warning text, that `resimulate.network` is actually flipped to `TRUE`, that it fires when the argument is omitted entirely, and that nothing is emitted when the settings already agree or `tergmLite` is off. Nothing previously asserted the reset itself.

## Not included

The `raw.records` naming item is left for #1059. The fix has not landed: `R/saveout.R:300` still reads `top_lvl_elts <- c("attr.history", ".records")`, so `name_saveout_elts()` gets `NULL` and the slot stays unnamed. A regression test would fail today. The one-line fix belongs with the rest of #1059 rather than in a coverage PR.

## Checks

Full `R CMD check` under R 4.6.1 with `NOT_CRAN = true`, so the long tests run: `Status: OK`, `FAIL 0 | WARN 1 | SKIP 0 | PASS 3277`, against `FAIL 0 | WARN 8 | SKIP 0 | PASS 3207` before.

The issue counts 7 warnings; there are 8 on a machine without `Rglpk`. The extra one is `ergm` reporting its fallback from `glpk` to `lpSolveAPI` inside `netest()`. It is environment-dependent, so wrapping it in `expect_warning()` would fail wherever `Rglpk` is installed. It is the one warning left after this PR.
